### PR TITLE
chore: vscode setting.json boolean 대신 string 사용하도록 변경

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,6 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }


### PR DESCRIPTION
### 관련 이슈

- close #16 

### 작업 요약

- vscode setting.json boolean 대신 string 사용하도록 변경

### 리뷰 요구 사항

- 리뷰 예상 시간 `1분`


