### PR TITLE
fix: 배포용 쉘 스크립트 경로 변경

### DIFF
--- a/.github/workflows/s3-develop-deploy.yml
+++ b/.github/workflows/s3-develop-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           aws s3 sync \
             --region ${{ secrets.AWS_REGION }} \
             tars ${{secrets.S3_DEV_FRONT_PATH}}
-            
+
   deploy_on_ec2:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -77,6 +77,6 @@ jobs:
           key: ${{ secrets.EC2_KEY_DEV }}
           envs: GITHUB_SHA
           script: |
-            cd ~/01-doo-re-front-infra
+            cd ~/01-doo-re-infrastructure/doo-re/deploy
             chmod +x ./deploy_front.sh
             sudo ./deploy_front.sh ${GITHUB_SHA::8} dev


### PR DESCRIPTION
### 관련 이슈

- #19 

### 작업 요약

- 배포용 쉘 스크립트 경로 변경

### 작업 상세 설명

- git action 코드와 서버에 업로드된 쉘 스크립트 경로가 일치하지 않아 맞춰줬습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간 : `1분`
