### PR TITLE
Feature/#36 프로필 테마 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "01-doo-re-front",
       "version": "0.1.0",
       "dependencies": {
+        "@chakra-ui/anatomy": "^2.2.2",
         "@chakra-ui/next-js": "^2.2.0",
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.11.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@chakra-ui/anatomy": "^2.2.2",
     "@chakra-ui/next-js": "^2.2.0",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.3",

--- a/src/theme/components/avatar.ts
+++ b/src/theme/components/avatar.ts
@@ -1,0 +1,32 @@
+import { avatarAnatomy } from '@chakra-ui/anatomy';
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react';
+
+const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(avatarAnatomy.keys);
+
+const Avatar = defineMultiStyleConfig({
+  sizes: {
+    sm: definePartsStyle({
+      container: {
+        h: '24px',
+        w: '24px',
+        shadow: 'base',
+      },
+    }),
+    md: definePartsStyle({
+      container: {
+        h: '38px',
+        w: '38px',
+        shadow: 'lg',
+      },
+    }),
+    lg: definePartsStyle({
+      container: {
+        h: '96px',
+        w: '96px',
+        shadow: 'lg',
+      },
+    }),
+  },
+});
+
+export default Avatar;

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -1,0 +1,26 @@
+import { defineStyleConfig } from '@chakra-ui/react';
+
+const Button = defineStyleConfig({
+  sizes: {
+    icon_sm: {
+      fontSize: 'xl',
+      h: '24px',
+      w: '24px',
+      borderRadius: 'full',
+    },
+    icon_md: {
+      fontSize: '2xl',
+      h: '38px',
+      w: '38px',
+      borderRadius: 'full',
+    },
+    icon_lg: {
+      fontSize: '3xl',
+      h: '68px',
+      w: '68px',
+      borderRadius: 'full',
+    },
+  },
+});
+
+export default Button;

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,3 +1,7 @@
-const components = {};
+import Button from './button';
+
+const components = {
+  Button,
+};
 
 export default components;

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,6 +1,8 @@
+import Avatar from './avatar';
 import Button from './button';
 
 const components = {
+  Avatar,
   Button,
 };
 


### PR DESCRIPTION
### 관련 이슈

- #38 선행 풀리퀘 부탁드립니다!
- close #36 

### 작업 요약

- 프로필 테마 설정
<img width="905" alt="image" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/81643702/9bfafb84-9dc0-41bc-b072-45595cf49b62">

- 프로필 이미지의 경우, Avatar 컴포넌트를 사용하는데, 이를 커스텀하려면 anatomy라는 패키지를 설치해줘야합니다. [공식문서 참고](https://chakra-ui.com/docs/components/avatar/theming)
- 이건 아이콘 프로필과 다르게 기본 속성인 sm, md, lg등을 커스텀해줬습니다. (icon_md등으로 새로만든게 아닙니다!)
- #38 에서도 설명드렸지만, 버튼 테마는 아이콘, 기본 버튼 등의 모든 테마가 공통적으로 적용되기 때문에, sm, md등으로 커스텀해버리면 다 적용이 되버립니다. 그래서 icon_sm등으로 새로 만들어준겁니다. 

### 예시코드
```ts
 <Avatar size={isOpen ? 'lg' : 'md'} src="" />
```
 

### 리뷰 요구 사항

- 1분
