### PR TITLE
Feature/#56 레이아웃 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,9 +10,9 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
     <html lang="en" className={fonts.rubik.variable}>
       <body>
         <Providers>
-          <Flex>
+          <Flex minH="100vh">
             <Sidebar />
-            {children}
+            <Flex flex="1">{children}</Flex>
           </Flex>
         </Providers>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-// TODO - 임시로 eslint 룰 무시했습니다. 추후 제거 필요
-
 'use client';
 
 import { Box, Grid, Text, Flex } from '@chakra-ui/react';
@@ -40,15 +37,12 @@ const Page = () => {
         </Grid>
         <ScrollDownButton onClick={() => mainSectionRef.current?.scrollNext()} />
       </Flex>
-      <Flex w="full" h="100vh">
-        임시
-      </Flex>
 
-      {/* <Box key="main" pos="relative" h="100vh">
+      <Box key="main" pos="relative" h="100vh">
         <TeamRankBG />
         <TeamRankDescription />
         <TeamRankSlider />
-      </Box> */}
+      </Box>
     </MainSection>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// TODO - 임시로 eslint 룰 무시했습니다. 추후 제거 필요
+
 'use client';
 
 import { Box, Grid, Text, Flex } from '@chakra-ui/react';
@@ -37,11 +40,15 @@ const Page = () => {
         </Grid>
         <ScrollDownButton onClick={() => mainSectionRef.current?.scrollNext()} />
       </Flex>
-      <Box key="main" pos="relative" w="100vw" h="100vh">
+      <Flex w="full" h="100vh">
+        임시
+      </Flex>
+
+      {/* <Box key="main" pos="relative" h="100vh">
         <TeamRankBG />
         <TeamRankDescription />
         <TeamRankSlider />
-      </Box>
+      </Box> */}
     </MainSection>
   );
 };

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -15,15 +15,7 @@ const Sidebar = () => {
   const [isOpen, setIsOpen] = useState(true);
 
   return (
-    <Flex
-      direction="column"
-      gap="16"
-      w={isOpen ? '72' : '20'}
-      h="100vh"
-      p="4"
-      bg="green"
-      transition="width 0.15s ease-in-out"
-    >
+    <Flex direction="column" gap="16" w={isOpen ? '72' : '20'} p="4" bg="green" transition="width 0.15s ease-in-out">
       <Flex justify={isOpen ? 'space-between' : 'center'}>
         {isOpen && (
           // TODO - 추후 로고 대체
@@ -58,7 +50,7 @@ const Sidebar = () => {
       </Flex>
 
       {isOpen && (
-        <Card direction="column" gap="4" h="100vh" p="4" bg="green_dark" rounded="2xl">
+        <Card direction="column" gap="4" h="100%" p="4" bg="green_dark" rounded="2xl">
           <Flex align="center" justify="space-between">
             <Text color="white" fontSize="xl" fontWeight="bold">
               TEAM & STUDY

--- a/src/containers/main/TeamRankDescription/index.tsx
+++ b/src/containers/main/TeamRankDescription/index.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from '@chakra-ui/react';
 const TeamRankDescription = () => {
   return (
     <Box
-      w="100vw"
+      w="100%"
       h="fit-content"
       p="70px 0px 30px 180px"
       color="#fff"

--- a/src/containers/main/TeamRankSlider/index.tsx
+++ b/src/containers/main/TeamRankSlider/index.tsx
@@ -24,7 +24,7 @@ const TeamRankSlider = () => {
   };
 
   return (
-    <Box pos="relative" w="100vw" h="400">
+    <Box pos="relative" w="100%" h="400">
       <Box pos="absolute" left={`calc(50% - ${780 * indexX}px)`} transform="translate(-50%, 0%)">
         {teamRankInfos.map((info, _) => {
           const leftScale = 780 * _;


### PR DESCRIPTION
### 관련 이슈

- close #56

### 작업 요약

- 레이아웃 width, height이 제대로 안보이는 문제 수정했습니다.
- 원래 페이지 내부 내용이 없을때, 있을때 사이드바 넓이가 차이났었는데, 고정시켰습니다.
- 팀 랭킹페이지의 경우 wdith를 오버해서 차지해서, 옆으로 스크롤이 생겼는데 해결했습니다.
 
### 작업 상세 설명

- 그런데 여전히 화면이 지나치게 작아아지면 스크롤이 자동으로 생기면서 잘리는 현상이 있는데, 이건 **사이드바 자체를 반응형으로** 바꿔줘야합니다. 즉 사이드바에 내용이 너무 길어져서 자동으로 스크롤이 생깁니다.  
- 이거는 아예 breakpoint로 sm일때 사이드바를 자동으로 닫히게 한다던가 해줘야할 것 같지만, 반응형보다는 다른 기능개발이 우선이기때문에, 추후에 **레이아웃 반응형** 으로 따로 이슈파서 작업해도 괜찮을까요?
<img width="1049" alt="image" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/81643702/06039f23-cad8-4b2d-8352-581b3d79a365">

### 리뷰 요구 사항

- 3분

### 미리 보기

<img width="1700" alt="image" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/81643702/4b10b442-e6a2-4dcb-b496-82175660d1b4">