### PR TITLE
Feature/#70 콘텐츠 넓이 고정

### DIFF
--- a/src/app/team/[teamId]/layout.tsx
+++ b/src/app/team/[teamId]/layout.tsx
@@ -1,0 +1,13 @@
+import { Flex } from '@chakra-ui/react';
+
+import size from '@/constants/size';
+
+const Layout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Flex justify="center" w="100%" bg="gray.50">
+      <Flex w={`calc(100vw - ${size.sidebarWidth})`}>{children}</Flex>
+    </Flex>
+  );
+};
+
+export default Layout;

--- a/src/app/team/[teamId]/page.tsx
+++ b/src/app/team/[teamId]/page.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Grid, GridItem } from '@chakra-ui/react';
 
 const Page = () => {
   return (
-    <Flex direction="column" gap="8" w="100%" p="8" bg="gray.50">
+    <Flex direction="column" gap="8" w="100%" p="8">
       <Flex justify="space-between" bg="gray.100">
         {/* TODO 이름 + 소개글 컴포넌트 */}
         <Box w="96" h="16" bg="gray.200" />

--- a/src/app/team/[teamId]/study/[studyId]/page.tsx
+++ b/src/app/team/[teamId]/study/[studyId]/page.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Grid, GridItem } from '@chakra-ui/react';
 
 const Page = () => {
   return (
-    <Flex gap="8" w="100%" p="8" bg="gray.50">
+    <Flex gap="8" w="100%" p="8">
       <Flex direction="column" gap="8" w="66%" bg="gray.100">
         {/* TODO 이름 + 소개글 컴포넌트 */}
         <Box w="96" h="16" bg="gray.200" />

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -6,6 +6,7 @@ import { BiBell, BiUser } from 'react-icons/bi';
 import { BsPlus, BsGrid } from 'react-icons/bs';
 import { MdOutlineLogout } from 'react-icons/md';
 
+import size from '@/constants/size';
 import sidebarData from '@/mocks/sidebar';
 
 import SidebarIconButton from './Button/SidebarIconButton';
@@ -15,7 +16,14 @@ const Sidebar = () => {
   const [isOpen, setIsOpen] = useState(true);
 
   return (
-    <Flex direction="column" gap="16" w={isOpen ? '60' : '16'} p="4" bg="green" transition="width 0.15s ease-in-out">
+    <Flex
+      direction="column"
+      gap="16"
+      w={isOpen ? size.sidebarWidth : '16'}
+      p="4"
+      bg="green"
+      transition="width 0.15s ease-in-out"
+    >
       <Flex justify={isOpen ? 'space-between' : 'center'}>
         {isOpen && (
           // TODO - 추후 로고 대체

--- a/src/constants/size.ts
+++ b/src/constants/size.ts
@@ -1,0 +1,5 @@
+const size = {
+  sidebarWidth: '240px',
+};
+
+export default size;


### PR DESCRIPTION
### 관련 이슈

- close #70 

### 작업 요약

- 팀, 스터디 고정된 넓이의 레이아웃 추가
- size 상수 추가
 

### 리뷰 요구 사항

- 1분

### 미리 보기

<img width="1675" alt="image" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/81643702/e29a67ca-4958-45bb-923a-a7066519de25">
<img width="1674" alt="image" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/81643702/4516670c-9e9c-44a6-ab9e-3aa632d316b1">
