### PR TITLE
Feature/#78 3D 잔디 회전 구현

### DIFF
--- a/src/components/Garden3D/index.tsx
+++ b/src/components/Garden3D/index.tsx
@@ -5,7 +5,7 @@ import './style.css';
 import Bar from './Bar';
 import { Garden3DProps } from './types';
 
-const Garden3D = ({ cubeSize, cubeGap, rotateY, gardenInfos }: Garden3DProps) => {
+const Garden3D = ({ rotate = false, cubeSize, cubeGap, rotateY, gardenInfos }: Garden3DProps) => {
   const cubeSizeHalf = cubeSize / 2;
 
   const offsetX = 300;

--- a/src/components/Garden3D/index.tsx
+++ b/src/components/Garden3D/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import './style.css';
 
 import Bar from './Bar';
@@ -18,8 +20,27 @@ const Garden3D = ({ rotate = false, cubeSize, cubeGap, rotateY, gardenInfos }: G
       return prev.count >= value.count ? prev : value;
     }).count / 4;
 
+  /* setting for drag event */
+  const [yDegree, setYDegree] = useState<number>(rotateY);
+
+  /* cube mouse drag event */
+  const mouseDown = (clickEvent: React.MouseEvent<Element, MouseEvent>) => {
+    const mouseMoveHandler = (moveEvent: MouseEvent) => {
+      const deltaX = moveEvent.screenX - clickEvent.screenX;
+
+      setYDegree(yDegree + deltaX);
+    };
+
+    const mouseUpHandler = () => {
+      document.removeEventListener('mousemove', mouseMoveHandler);
+    };
+
+    document.addEventListener('mousemove', mouseMoveHandler);
+    document.addEventListener('mouseup', mouseUpHandler, { once: true });
+  };
+
   return (
-    <div className="container" role="textbox" tabIndex={0}>
+    <div className="container" onMouseDown={rotate ? mouseDown : undefined} role="textbox" tabIndex={0}>
       <div className="fake_scene">
         {gardenInfos.map((info) => {
           const currZ = offsetZ + (info.date - 3) * gap;
@@ -30,7 +51,7 @@ const Garden3D = ({ rotate = false, cubeSize, cubeGap, rotateY, gardenInfos }: G
               key={info.id}
               className="scene"
               style={{
-                transform: `rotateY(${rotateY}deg)`,
+                transform: `rotateY(${yDegree}deg)`,
               }}
             >
               <Bar

--- a/src/components/Garden3D/types.ts
+++ b/src/components/Garden3D/types.ts
@@ -10,6 +10,7 @@ export interface CubeProps {
 }
 
 export interface Garden3DProps {
+  rotate?: boolean;
   cubeSize: number;
   cubeGap: number;
   rotateY: number;


### PR DESCRIPTION
### 관련 이슈

- close #78 

### 작업 요약

- Garden 3D  컴포넌트에 회전하는 기능 추가

### 작업 상세 설명

- Garden 3D props 의 rotate === true 일때만 회전함.

### 리뷰 요구 사항

- 리뷰예상 시간 : `1분`
```tsx
'use client';

import Garden3D from '@/components/Garden3D';
import { gardenInfos1 } from '@/mocks/Garden3D';

const Page = () => {
  return <Garden3D rotate cubeSize={24} cubeGap={4} rotateY={55} gardenInfos={gardenInfos1} />;
};

export default Page;

```
