### PR TITLE
Feature/#86 gardend3D 컴포넌트 크기 확대

### DIFF
--- a/src/components/Garden3D/index.tsx
+++ b/src/components/Garden3D/index.tsx
@@ -11,7 +11,7 @@ const Garden3D = ({ rotate = false, cubeSize, cubeGap, rotateY, gardenInfos }: G
   const cubeSizeHalf = cubeSize / 2;
 
   const offsetX = 300;
-  const offsetDefaultY = 530;
+  const offsetDefaultY = 545;
   const [offsetY, setOffsetY] = useState<number>(offsetDefaultY);
   const offsetZ = 0;
   const gap = cubeSize + cubeGap;

--- a/src/components/Garden3D/index.tsx
+++ b/src/components/Garden3D/index.tsx
@@ -5,7 +5,7 @@ import './style.css';
 import Bar from './Bar';
 import { Garden3DProps } from './types';
 
-const Garden3D = ({ cubeSize, cubeGap, rotateY, gardenInfos }: Garden3DProps) => {
+const Garden3D = ({ rotate = false, cubeSize, cubeGap, rotateY, gardenInfos }: Garden3DProps) => {
   const cubeSizeHalf = cubeSize / 2;
 
   const offsetX = 300;

--- a/src/components/Garden3D/index.tsx
+++ b/src/components/Garden3D/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import './style.css';
 
 import Bar from './Bar';
@@ -18,8 +20,27 @@ const Garden3D = ({ rotate = false, cubeSize, cubeGap, rotateY, gardenInfos }: G
       return prev.count >= value.count ? prev : value;
     }).count / 4;
 
+  /* setting for drag event */
+  const [yDegree, setYDegree] = useState<number>(rotateY);
+
+  /* cube mouse drag event */
+  const mouseDown = (clickEvent: React.MouseEvent<Element, MouseEvent>) => {
+    const mouseMoveHandler = (moveEvent: MouseEvent) => {
+      const deltaX = moveEvent.screenX - clickEvent.screenX;
+
+      setYDegree(yDegree + deltaX);
+    };
+
+    const mouseUpHandler = () => {
+      document.removeEventListener('mousemove', mouseMoveHandler);
+    };
+
+    document.addEventListener('mousemove', mouseMoveHandler);
+    document.addEventListener('mouseup', mouseUpHandler, { once: true });
+  };
+
   return (
-    <div className="container" role="textbox" tabIndex={0}>
+    <div className="container" onMouseDown={rotate ? mouseDown : undefined} role="textbox" tabIndex={0}>
       <div className="fake_scene">
         {gardenInfos.map((info) => {
           const currZ = offsetZ + (info.date - 3) * gap;
@@ -30,7 +51,7 @@ const Garden3D = ({ rotate = false, cubeSize, cubeGap, rotateY, gardenInfos }: G
               key={info.id}
               className="scene"
               style={{
-                transform: `rotateY(${rotateY}deg)`,
+                transform: `rotateY(${yDegree}deg)`,
               }}
             >
               <Bar

--- a/src/components/Garden3D/index.tsx
+++ b/src/components/Garden3D/index.tsx
@@ -11,7 +11,8 @@ const Garden3D = ({ rotate = false, cubeSize, cubeGap, rotateY, gardenInfos }: G
   const cubeSizeHalf = cubeSize / 2;
 
   const offsetX = 300;
-  const offsetY = 530;
+  const offsetDefaultY = 530;
+  const [offsetY, setOffsetY] = useState<number>(offsetDefaultY);
   const offsetZ = 0;
   const gap = cubeSize + cubeGap;
   const standX = (gardenInfos[gardenInfos.length - 1].week - gardenInfos[0].week + 1) / 2 + gardenInfos[0].week;
@@ -28,6 +29,10 @@ const Garden3D = ({ rotate = false, cubeSize, cubeGap, rotateY, gardenInfos }: G
     const mouseMoveHandler = (moveEvent: MouseEvent) => {
       const deltaX = moveEvent.screenX - clickEvent.screenX;
 
+      const calcY = Math.abs((yDegree + deltaX) % 180);
+
+      if (calcY < 90) setOffsetY(offsetDefaultY - calcY / 2);
+      else setOffsetY(offsetDefaultY + (calcY - 180) / 2);
       setYDegree(yDegree + deltaX);
     };
 

--- a/src/components/Garden3D/index.tsx
+++ b/src/components/Garden3D/index.tsx
@@ -11,7 +11,7 @@ const Garden3D = ({ rotate = false, cubeSize, cubeGap, rotateY, gardenInfos }: G
   const cubeSizeHalf = cubeSize / 2;
 
   const offsetX = 300;
-  const offsetY = 500;
+  const offsetY = 530;
   const offsetZ = 0;
   const gap = cubeSize + cubeGap;
   const standX = (gardenInfos[gardenInfos.length - 1].week - gardenInfos[0].week + 1) / 2 + gardenInfos[0].week;

--- a/src/components/Garden3D/style.css
+++ b/src/components/Garden3D/style.css
@@ -1,6 +1,6 @@
 .container {
   width: 600px;
-  height: 300px;
+  height: 350px;
   position: relative;
   overflow: hidden;
 }

--- a/src/components/Garden3D/types.ts
+++ b/src/components/Garden3D/types.ts
@@ -10,6 +10,7 @@ export interface CubeProps {
 }
 
 export interface Garden3DProps {
+  rotate?: boolean;
   cubeSize: number;
   cubeGap: number;
   rotateY: number;

--- a/src/containers/main/TeamCard/index.tsx
+++ b/src/containers/main/TeamCard/index.tsx
@@ -71,7 +71,7 @@ const TeamCard = ({ rank, name, description, gardenInfos }: TeamCardProps) => {
           left="100%"
           w="fit-content"
           h="fit-content"
-          transform="translate(-80%, 0%)"
+          transform="translate(-80%, -10%)"
         >
           <Garden3D cubeSize={24} cubeGap={4} rotateY={55} gardenInfos={gardenInfos} />
         </Box>


### PR DESCRIPTION
### 관련 이슈

- 이전 이슈 : #78 
- close #86 

### 작업 상세 설명
- Garden3D의 height의 크기가 작아서, 팀페이지에 넣으면 cube(텃밭 1개)의 크기를 늘렸을 때, 안보일 거라 생각해서 크기를 늘림.
    (근데 지금 생각해보니까, overflow: hidden 안 해놓아서, 수정 안 했더라도 안보이는 형상 없음.ㅋㅋㅋㅋ)
- 팀페이지에서 보이기에는 텃밭이 화면의 위에 있어서 아래로 내림.
- 위에서 텃밭의 y축을 올린 만큼, 팀 랭킹 페이지에 보이는 Garden을 내림.

### 리뷰 요구 사항

- 리뷰예상 시간: `1분`

### 미리 보기

https://github.com/BDD-CLUB/01-doo-re-front/assets/77055208/ed50e138-faea-4118-99ff-8fc0c9604613


