### PR TITLE
Feature/#90 팀 카드 애니메이션 구현

### DIFF
--- a/src/containers/main/TeamRankSlider/index.tsx
+++ b/src/containers/main/TeamRankSlider/index.tsx
@@ -25,7 +25,12 @@ const TeamRankSlider = () => {
 
   return (
     <Box pos="relative" w="100%" h="400">
-      <Box pos="absolute" left={`calc(50% - ${780 * indexX}px)`} transform="translate(-50%, 0%)">
+      <Box
+        pos="absolute"
+        left={`calc(50% - ${780 * indexX}px)`}
+        transform="translate(-50%, 0%)"
+        transition="left 1s ease-in-out 0s"
+      >
         {teamRankInfos.map((info, _) => {
           const leftScale = 780 * _;
           return (


### PR DESCRIPTION
### 관련 이슈

- #90

### 작업 요약

- 팀 랭킹에서 slide 넘어가는 애니메이션 구현

### 리뷰 요구 사항

- 리뷰 예상 시간: `1초`

### 미리 보기

https://github.com/BDD-CLUB/01-doo-re-front/assets/77055208/8a1442e2-77cd-41b6-8565-2252fb357bdd


