### PR TITLE
Feature/#132 반응형 폰트 스타일 수정

### DIFF
--- a/src/theme/breakpoints.ts
+++ b/src/theme/breakpoints.ts
@@ -1,0 +1,10 @@
+const breakpoints = {
+  base: '0px',
+  sm: '480px',
+  md: '768px',
+  lg: '992px',
+  xl: '1300px',
+  '2xl': '1536px',
+};
+
+export default breakpoints;

--- a/src/theme/foundations/textStyles.ts
+++ b/src/theme/foundations/textStyles.ts
@@ -1,32 +1,32 @@
 const textStyles = {
   bold_4xl: {
-    fontSize: { base: '40px', lg: '44px', '2xl': '48px' },
+    fontSize: { base: '32px', xl: '36px' },
     fontWeight: 'bold',
   },
   bold_3xl: {
-    fontSize: { base: '32px', lg: '36px', '2xl': '40px' },
+    fontSize: { base: '28px', xl: '30px' },
     fontWeight: 'bold',
   },
   bold_2xl: {
-    fontSize: { base: '22px', lg: '26px', '2xl': '30px' },
+    fontSize: { base: '22px', xl: '24px' },
     fontWeight: 'bold',
   },
   bold_xl: {
-    fontSize: { base: '16px', lg: '18px', '2xl': '20px' },
+    fontSize: { base: '18px', xl: '20px' },
     fontWeight: 'bold',
   },
   bold_md: {
-    fontSize: { base: '12px', lg: '14px', '2xl': '16px' },
+    fontSize: { base: '14px', xl: '16px' },
     fontWeight: 'bold',
   },
   md: {
-    fontSize: { base: '12px', lg: '14px', '2xl': '16px' },
+    fontSize: { base: '14px', xl: '16px' },
   },
   sm: {
-    fontSize: { base: '8px', lg: '10px', '2xl': '12px' },
+    fontSize: { base: '12px', xl: '14px' },
   },
   title_xl: {
-    fontSize: { base: '80px', lg: '100px', '2xl': '130px' },
+    fontSize: { base: '80px', lg: '80px', '2xl': '130px' },
     fontWeight: 'black',
   },
   title_bold_xl: {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,17 +1,9 @@
 import { extendTheme } from '@chakra-ui/react';
 
+import breakpoints from './breakpoints';
 import components from './components';
 import foundations from './foundations';
 import styles from './styles';
-
-const breakpoints = {
-  base: '0px',
-  sm: '480px',
-  md: '768px',
-  lg: '992px',
-  xl: '1300px',
-  '2xl': '1536px',
-};
 
 const theme = extendTheme({
   breakpoints,

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -4,7 +4,17 @@ import components from './components';
 import foundations from './foundations';
 import styles from './styles';
 
+const breakpoints = {
+  base: '0px',
+  sm: '480px',
+  md: '768px',
+  lg: '992px',
+  xl: '1300px',
+  '2xl': '1536px',
+};
+
 const theme = extendTheme({
+  breakpoints,
   styles,
   ...foundations,
   components,


### PR DESCRIPTION
### 관련 이슈
- close #132 

### 작업 요약
- 오늘 회의했던 결과대로, 폰트 크기를 2단계로 나누어지도록 수정했습니다.
- breakpoints 개별 변경이 적용되지 않아, 일괄로 xl 사이즈를 1280px 에서 1300px로 지정해주었습니다.
- 폰트 크기는 xl(1300px) 이상일 때 차크라의 기본 폰트 크기이고, 그 이하일 때는 2px 내진 4px이 줄어들도록 했습니다.

### 리뷰 요구 사항
- 리뷰 예상 시간: `30초`