### PR TITLE
Feature/#123 팀 카드 반응형 수정

### DIFF
--- a/src/containers/main/TeamCard/index.tsx
+++ b/src/containers/main/TeamCard/index.tsx
@@ -43,7 +43,7 @@ const TeamCard = ({ rank, name, description, gardenInfos }: TeamCardProps) => {
             textStyle="md"
             overflow="hidden"
             w={{ base: '250px', lg: '300px', '2xl': '350px' }}
-            maxH={{ base: '11', xl: '12' }}
+            maxH={{ base: '44px', xl: '48px' }}
             whiteSpace="wrap"
           >
             {description === '' ? '팀 소개글이 아직 없습니다.' : description}

--- a/src/containers/main/TeamCard/index.tsx
+++ b/src/containers/main/TeamCard/index.tsx
@@ -1,13 +1,10 @@
-import { Box, Card, CardHeader, Text, Flex, CardBody, useMediaQuery } from '@chakra-ui/react';
+import { Box, Card, CardHeader, Text, Flex, CardBody, useBreakpointValue } from '@chakra-ui/react';
 
 import Garden3D from '@/components/Garden3D';
 
 import { TeamCardProps } from './types';
 
 const TeamCard = ({ rank, name, description, gardenInfos }: TeamCardProps) => {
-  const [isLargerThan992] = useMediaQuery('(min-width: 992px)');
-  const [isLargerThan1536] = useMediaQuery('(min-width: 1536px)');
-
   return (
     <Card overflow="hidden" w="100%" h="100%" bg="none" backdropFilter="blur(30px)">
       <CardHeader
@@ -59,13 +56,12 @@ const TeamCard = ({ rank, name, description, gardenInfos }: TeamCardProps) => {
         h={{ base: '95%', lg: '90%' }}
         p="0"
       >
-        {isLargerThan1536 && <Garden3D cubeSize={32} cubeGap={4} rotateY={55} gardenInfos={gardenInfos} />}
-        {!isLargerThan1536 &&
-          (isLargerThan992 ? (
-            <Garden3D cubeSize={24} cubeGap={4} rotateY={55} gardenInfos={gardenInfos} />
-          ) : (
-            <Garden3D cubeSize={18} cubeGap={4} rotateY={55} gardenInfos={gardenInfos} />
-          ))}
+        <Garden3D
+          cubeSize={useBreakpointValue({ base: 18, lg: 24, '2xl': 32 }) || 18}
+          cubeGap={4}
+          rotateY={55}
+          gardenInfos={gardenInfos}
+        />
       </CardBody>
     </Card>
   );

--- a/src/containers/main/TeamCard/index.tsx
+++ b/src/containers/main/TeamCard/index.tsx
@@ -51,7 +51,7 @@ const TeamCard = ({ rank, name, description, gardenInfos }: TeamCardProps) => {
         pos="absolute"
         zIndex="-1"
         top={{ base: '0%', lg: '10%' }}
-        left={{ base: '28%', lg: '30%', '2xl': '30%' }}
+        left={{ base: '28%', lg: '30%' }}
         w="80%"
         h={{ base: '95%', lg: '90%' }}
         p="0"

--- a/src/containers/main/TeamCard/index.tsx
+++ b/src/containers/main/TeamCard/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Card, CardHeader, Text, Flex, CardBody, useMediaQuery } from '@chakra-ui/react';
-import { useEffect } from 'react';
 
 import Garden3D from '@/components/Garden3D';
 
@@ -8,10 +7,6 @@ import { TeamCardProps } from './types';
 const TeamCard = ({ rank, name, description, gardenInfos }: TeamCardProps) => {
   const [isLargerThan992] = useMediaQuery('(min-width: 992px)');
   const [isLargerThan1536] = useMediaQuery('(min-width: 1536px)');
-
-  useEffect(() => {
-    console.log(isLargerThan992, isLargerThan1536);
-  }, [isLargerThan992, isLargerThan1536]);
 
   return (
     <Card overflow="hidden" w="100%" h="100%" bg="none" backdropFilter="blur(30px)">

--- a/src/containers/main/TeamCard/index.tsx
+++ b/src/containers/main/TeamCard/index.tsx
@@ -16,7 +16,7 @@ const TeamCard = ({ rank, name, description, gardenInfos }: TeamCardProps) => {
         color="white"
       >
         <Box pos="relative" w={{ base: '100px', lg: '120px', '2xl': '170px' }}>
-          <Text textStyle="title_bold_xl" fontFamily="Inter" textAlign="right">
+          <Text textStyle="title_bold_xl" textAlign="right">
             {rank}
           </Text>
           <Box pos="absolute" top={{ base: '110px', lg: '150px', '2xl': '170px' }} w="100%">

--- a/src/containers/main/TeamCard/index.tsx
+++ b/src/containers/main/TeamCard/index.tsx
@@ -51,8 +51,8 @@ const TeamCard = ({ rank, name, description, gardenInfos }: TeamCardProps) => {
         pos="absolute"
         zIndex="-1"
         top={{ base: '0%', lg: '10%' }}
-        left={{ base: '28%', lg: '30%', '2xl': '35%' }}
-        w={{ base: '80%', lg: '80%', '2xl': '70%' }}
+        left={{ base: '28%', lg: '30%', '2xl': '30%' }}
+        w="80%"
         h={{ base: '95%', lg: '90%' }}
         p="0"
       >

--- a/src/containers/main/TeamCard/index.tsx
+++ b/src/containers/main/TeamCard/index.tsx
@@ -1,43 +1,38 @@
-import { Box, Card, CardHeader, Text } from '@chakra-ui/react';
+import { Box, Card, CardHeader, Text, Flex, CardBody, useMediaQuery } from '@chakra-ui/react';
+import { useEffect } from 'react';
 
 import Garden3D from '@/components/Garden3D';
 
 import { TeamCardProps } from './types';
 
-import './style.css';
-
 const TeamCard = ({ rank, name, description, gardenInfos }: TeamCardProps) => {
+  const [isLargerThan992] = useMediaQuery('(min-width: 992px)');
+  const [isLargerThan1536] = useMediaQuery('(min-width: 1536px)');
+
+  useEffect(() => {
+    console.log(isLargerThan992, isLargerThan1536);
+  }, [isLargerThan992, isLargerThan1536]);
+
   return (
-    <Card overflow="hidden" w="650px" h="350px" bg="none" borderRadius="30" backdropFilter="blur(30px)">
-      <Box pos="relative" zIndex="60" w="100%" h="100%" bg="rgba(255, 255, 255, 0.1)">
-        <CardHeader
-          alignItems="center"
-          justifyContent="left"
-          gap="10"
-          display="flex"
-          w="100%"
-          h="120"
-          px="0"
-          pt="5"
-          pb="0"
-          bg="none"
-        >
-          <Box
-            pos="relative"
-            w="18%"
-            h="100%"
-            pr="2"
-            borderBottom="1px"
-            borderBottomStyle="solid"
-            borderBottomColor="white"
-          >
-            <Text color="white" fontFamily="Inter" fontSize="80" fontWeight="700" textAlign="right" fontStyle="normal">
-              {rank}
-            </Text>
+    <Card overflow="hidden" w="100%" h="100%" bg="none" backdropFilter="blur(30px)">
+      <CardHeader
+        gap={{ base: '6', lg: '8', '2xl': '10' }}
+        display="flex"
+        w="100%"
+        h={{ base: '110px', lg: '150px', '2xl': '170px' }}
+        p="0"
+        color="white"
+      >
+        <Box pos="relative" w={{ base: '100px', lg: '120px', '2xl': '170px' }}>
+          <Text textStyle="title_bold_xl" fontFamily="Inter" textAlign="right">
+            {rank}
+          </Text>
+          <Box pos="absolute" top={{ base: '110px', lg: '150px', '2xl': '170px' }} w="100%">
+            <Box className="bar" w="100%" h="2px" bg="white" />
             <Box
               className="circle"
               pos="absolute"
-              top="100%"
+              top="0%"
               left="100%"
               w="2"
               h="2"
@@ -46,36 +41,37 @@ const TeamCard = ({ rank, name, description, gardenInfos }: TeamCardProps) => {
               transform="translate(-50%, -50%)"
             />
           </Box>
-          <Box>
-            <Text color="white" fontFamily="Inter" fontSize="36" fontWeight="700" textAlign="left" fontStyle="normal">
-              {name}
-            </Text>
-            <Text
-              className="team_description"
-              zIndex="20"
-              color="white"
-              fontFamily="Inter"
-              fontSize="16"
-              fontWeight="400"
-              textAlign="left"
-              fontStyle="normal"
-            >
-              {description === '' ? '팀 소개글이 아직 없습니다.' : description}
-            </Text>
-          </Box>
-        </CardHeader>
-        <Box
-          pos="absolute"
-          zIndex="-1"
-          top="20%"
-          left="100%"
-          w="fit-content"
-          h="fit-content"
-          transform="translate(-80%, -10%)"
-        >
-          <Garden3D cubeSize={24} cubeGap={4} rotateY={55} gardenInfos={gardenInfos} />
         </Box>
-      </Box>
+        <Flex direction="column" w="full" pt={{ base: '6', lg: '7', '2xl': '10' }}>
+          <Text textStyle="bold_4xl">{name}</Text>
+          <Text
+            textStyle="md"
+            overflow="hidden"
+            w={{ base: '250px', lg: '300px', '2xl': '350px' }}
+            maxH={{ base: '11', xl: '12' }}
+            whiteSpace="wrap"
+          >
+            {description === '' ? '팀 소개글이 아직 없습니다.' : description}
+          </Text>
+        </Flex>
+      </CardHeader>
+      <CardBody
+        pos="absolute"
+        zIndex="-1"
+        top={{ base: '0%', lg: '10%' }}
+        left={{ base: '28%', lg: '30%', '2xl': '35%' }}
+        w={{ base: '80%', lg: '80%', '2xl': '70%' }}
+        h={{ base: '95%', lg: '90%' }}
+        p="0"
+      >
+        {isLargerThan1536 && <Garden3D cubeSize={32} cubeGap={4} rotateY={55} gardenInfos={gardenInfos} />}
+        {!isLargerThan1536 &&
+          (isLargerThan992 ? (
+            <Garden3D cubeSize={24} cubeGap={4} rotateY={55} gardenInfos={gardenInfos} />
+          ) : (
+            <Garden3D cubeSize={18} cubeGap={4} rotateY={55} gardenInfos={gardenInfos} />
+          ))}
+      </CardBody>
     </Card>
   );
 };

--- a/src/containers/main/TeamCard/style.css
+++ b/src/containers/main/TeamCard/style.css
@@ -1,8 +1,0 @@
-.team_description {
-  width: 250px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}

--- a/src/containers/main/TeamRankSlider/index.tsx
+++ b/src/containers/main/TeamRankSlider/index.tsx
@@ -8,6 +8,8 @@ import 'swiper/css';
 
 import teamRankInfos from '@/mocks/TeamRanking';
 
+import TeamCard from '../TeamCard';
+
 const TeamRankSlider = () => {
   const [swiperIndex, setSwiperIndex] = useState<number>(0);
   const [swiper, setSwiper] = useState<SwiperClass>();
@@ -25,11 +27,19 @@ const TeamRankSlider = () => {
           {teamRankInfos.map((data) => (
             <SwiperSlide key={data.id} style={{ width: 'fit-content' }}>
               <Box
+                overflow="hidden"
                 w={{ base: '450px', lg: '600px', '2xl': '720px' }}
                 h={{ base: '300px', lg: '360px', '2xl': '430px' }}
-                bg="white"
+                bg="rgba(255, 255, 255, 0.1)"
+                borderRadius="30"
+                // bg="white"
               >
-                {/* TODO - 팀 카드 넣기 */}
+                <TeamCard
+                  rank={data.rank}
+                  name={data.name}
+                  description={data.description}
+                  gardenInfos={data.gardenInfos}
+                />
               </Box>
             </SwiperSlide>
           ))}

--- a/src/containers/main/TeamRankSlider/index.tsx
+++ b/src/containers/main/TeamRankSlider/index.tsx
@@ -27,11 +27,14 @@ const TeamRankSlider = () => {
           {teamRankInfos.map((data) => (
             <SwiperSlide key={data.id} style={{ width: 'fit-content' }}>
               <Box
+                as="a"
+                display="block"
                 overflow="hidden"
                 w={{ base: '450px', lg: '600px', '2xl': '720px' }}
                 h={{ base: '300px', lg: '360px', '2xl': '430px' }}
                 bg="rgba(255, 255, 255, 0.1)"
                 borderRadius="30"
+                href={data.url}
               >
                 <TeamCard
                   rank={data.rank}

--- a/src/containers/main/TeamRankSlider/index.tsx
+++ b/src/containers/main/TeamRankSlider/index.tsx
@@ -32,7 +32,6 @@ const TeamRankSlider = () => {
                 h={{ base: '300px', lg: '360px', '2xl': '430px' }}
                 bg="rgba(255, 255, 255, 0.1)"
                 borderRadius="30"
-                // bg="white"
               >
                 <TeamCard
                   rank={data.rank}

--- a/src/containers/main/TeamRankSlider/index.tsx
+++ b/src/containers/main/TeamRankSlider/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Box, Flex } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { Swiper, SwiperSlide, SwiperClass } from 'swiper/react';
 
@@ -13,6 +14,15 @@ import TeamCard from '../TeamCard';
 const TeamRankSlider = () => {
   const [swiperIndex, setSwiperIndex] = useState<number>(0);
   const [swiper, setSwiper] = useState<SwiperClass>();
+  const router = useRouter();
+
+  const slideOnClick = (idx: number, url: string) => {
+    if (swiper?.activeIndex === idx) {
+      router.push(url);
+    } else {
+      swiper?.slideTo(idx);
+    }
+  };
 
   return (
     <Flex align="center" direction="column" w="100%">
@@ -27,14 +37,12 @@ const TeamRankSlider = () => {
           {teamRankInfos.map((data) => (
             <SwiperSlide key={data.id} style={{ width: 'fit-content' }}>
               <Box
-                as="a"
-                display="block"
                 overflow="hidden"
                 w={{ base: '450px', lg: '600px', '2xl': '720px' }}
                 h={{ base: '300px', lg: '360px', '2xl': '430px' }}
                 bg="rgba(255, 255, 255, 0.1)"
                 borderRadius="30"
-                href={swiper?.activeIndex === data.idx ? data.url : undefined}
+                onClick={() => slideOnClick(data.idx, data.url)}
               >
                 <TeamCard
                   rank={data.rank}

--- a/src/containers/main/TeamRankSlider/index.tsx
+++ b/src/containers/main/TeamRankSlider/index.tsx
@@ -34,7 +34,7 @@ const TeamRankSlider = () => {
                 h={{ base: '300px', lg: '360px', '2xl': '430px' }}
                 bg="rgba(255, 255, 255, 0.1)"
                 borderRadius="30"
-                href={data.url}
+                href={swiper?.activeIndex === data.idx ? data.url : undefined}
               >
                 <TeamCard
                   rank={data.rank}

--- a/src/mocks/TeamRanking.ts
+++ b/src/mocks/TeamRanking.ts
@@ -10,7 +10,7 @@ const teamRankInfos: TeamRankInfoType[] = [
     name: '부산회',
     description:
       '안녕하십니까, 부산 시민 여러분. 오늘도 평안한 날을 지내시고 계신지요. 이 화창한 날 한번 바깥 구경도 해보고, 음냐링... 그냥 긴 문자열 만들어야하는데... 어떻게 하면 길게 적을 수 있을까.. 고민이된다.. 이정도면 긴 문자열로 처리가 되겠지? 약간만 더 적어보자!! 하하 잠자고 싶어ㅠㅠ',
-    url: 'teams/1',
+    url: '/team/1',
     gardenInfos: userInfos,
   },
   {
@@ -19,7 +19,7 @@ const teamRankInfos: TeamRankInfoType[] = [
     rank: 2,
     name: '열사모',
     description: '안녕하세요. 열정을 사랑하는 사람들의 모입에 오신 것을 환영합니다 :)',
-    url: 'teams/1',
+    url: '/team/1',
     gardenInfos: gardenInfos1,
   },
   {
@@ -28,17 +28,17 @@ const teamRankInfos: TeamRankInfoType[] = [
     rank: 3,
     name: '청명회',
     description: '화산의 검이 재현하려는 것은 매화가 아니다. 바로 ‘피어남’ 이다.',
-    url: 'teams/1',
+    url: '/team/1',
     gardenInfos: gardenInfos2,
   },
-  { id: 4, idx: 3, rank: 4, name: 'AJR', description: '', url: 'teams/1', gardenInfos: gardenInfos3 },
+  { id: 4, idx: 3, rank: 4, name: 'AJR', description: '', url: '/team/1', gardenInfos: gardenInfos3 },
   {
     id: 5,
     idx: 4,
     rank: 5,
     name: '캐럿',
     description: '대한민국의 13인조 보이그룹 세븐틴의 공식 팬클럽',
-    url: 'teams/1',
+    url: '/team/1',
     gardenInfos: userInfos,
   },
   {
@@ -48,7 +48,7 @@ const teamRankInfos: TeamRankInfoType[] = [
     name: '어린 왕자',
     description:
       '어린 왕자는 프랑스 공군 비행사이자 작가인 앙투안 드 생텍쥐페리(Antoine de Saint-Exupéry)가 1943년 발표한 소설이다. 또한 동시에 생텍쥐페리의 유작이기도 하다.',
-    url: 'teams/1',
+    url: '/team/1',
     gardenInfos: gardenInfos1,
   },
   {
@@ -57,7 +57,7 @@ const teamRankInfos: TeamRankInfoType[] = [
     rank: 7,
     name: '멜로디',
     description: '음의 높낮이의 변화가 리듬과 연결되어 흐르는 것.',
-    url: 'teams/1',
+    url: '/team/1',
     gardenInfos: gardenInfos2,
   },
   {
@@ -66,7 +66,7 @@ const teamRankInfos: TeamRankInfoType[] = [
     rank: 8,
     name: '네버랜드',
     description: '피터팬 속 상상의 공간 네버랜드에 사는 사람들은 변하지 않고 영원히 아이로 살 수 있는데',
-    url: 'teams/1',
+    url: '/team/1',
     gardenInfos: gardenInfos3,
   },
   {
@@ -75,10 +75,10 @@ const teamRankInfos: TeamRankInfoType[] = [
     rank: 9,
     name: 'BLINK',
     description: '시작과 끝을 함께하자',
-    url: 'teams/1',
+    url: '/team/1',
     gardenInfos: userInfos,
   },
-  { id: 10, idx: 9, rank: 10, name: 'John K', description: '', url: 'teams/1', gardenInfos: gardenInfos1 },
+  { id: 10, idx: 9, rank: 10, name: 'John K', description: '', url: '/team/1', gardenInfos: gardenInfos1 },
 ];
 
 export default teamRankInfos;

--- a/src/mocks/TeamRanking.ts
+++ b/src/mocks/TeamRanking.ts
@@ -9,7 +9,8 @@ const teamRankInfos: TeamRankInfoType[] = [
     rank: 1,
     name: '부산회',
     description:
-      '안녕하십니까, 부산 시민 여러분. 오늘도 평안한 날을 지내시고 계신지요. 이 화창한 날 한번 바깥 구경도 해보고, 으이',
+      '안녕하십니까, 부산 시민 여러분. 오늘도 평안한 날을 지내시고 계신지요. 이 화창한 날 한번 바깥 구경도 해보고, 음냐링... 그냥 긴 문자열 만들어야하는데... 어떻게 하면 길게 적을 수 있을까.. 고민이된다.. 이정도면 긴 문자열로 처리가 되겠지? 약간만 더 적어보자!! 하하 잠자고 싶어ㅠㅠ',
+    url: 'teams/1',
     gardenInfos: userInfos,
   },
   {
@@ -18,6 +19,7 @@ const teamRankInfos: TeamRankInfoType[] = [
     rank: 2,
     name: '열사모',
     description: '안녕하세요. 열정을 사랑하는 사람들의 모입에 오신 것을 환영합니다 :)',
+    url: 'teams/1',
     gardenInfos: gardenInfos1,
   },
   {
@@ -26,15 +28,17 @@ const teamRankInfos: TeamRankInfoType[] = [
     rank: 3,
     name: '청명회',
     description: '화산의 검이 재현하려는 것은 매화가 아니다. 바로 ‘피어남’ 이다.',
+    url: 'teams/1',
     gardenInfos: gardenInfos2,
   },
-  { id: 4, idx: 3, rank: 4, name: 'AJR', description: '', gardenInfos: gardenInfos3 },
+  { id: 4, idx: 3, rank: 4, name: 'AJR', description: '', url: 'teams/1', gardenInfos: gardenInfos3 },
   {
     id: 5,
     idx: 4,
     rank: 5,
     name: '캐럿',
     description: '대한민국의 13인조 보이그룹 세븐틴의 공식 팬클럽',
+    url: 'teams/1',
     gardenInfos: userInfos,
   },
   {
@@ -44,6 +48,7 @@ const teamRankInfos: TeamRankInfoType[] = [
     name: '어린 왕자',
     description:
       '어린 왕자는 프랑스 공군 비행사이자 작가인 앙투안 드 생텍쥐페리(Antoine de Saint-Exupéry)가 1943년 발표한 소설이다. 또한 동시에 생텍쥐페리의 유작이기도 하다.',
+    url: 'teams/1',
     gardenInfos: gardenInfos1,
   },
   {
@@ -52,6 +57,7 @@ const teamRankInfos: TeamRankInfoType[] = [
     rank: 7,
     name: '멜로디',
     description: '음의 높낮이의 변화가 리듬과 연결되어 흐르는 것.',
+    url: 'teams/1',
     gardenInfos: gardenInfos2,
   },
   {
@@ -60,10 +66,19 @@ const teamRankInfos: TeamRankInfoType[] = [
     rank: 8,
     name: '네버랜드',
     description: '피터팬 속 상상의 공간 네버랜드에 사는 사람들은 변하지 않고 영원히 아이로 살 수 있는데',
+    url: 'teams/1',
     gardenInfos: gardenInfos3,
   },
-  { id: 9, idx: 8, rank: 9, name: 'BLINK', description: '시작과 끝을 함께하자', gardenInfos: userInfos },
-  { id: 10, idx: 9, rank: 10, name: 'John K', description: '', gardenInfos: gardenInfos1 },
+  {
+    id: 9,
+    idx: 8,
+    rank: 9,
+    name: 'BLINK',
+    description: '시작과 끝을 함께하자',
+    url: 'teams/1',
+    gardenInfos: userInfos,
+  },
+  { id: 10, idx: 9, rank: 10, name: 'John K', description: '', url: 'teams/1', gardenInfos: gardenInfos1 },
 ];
 
 export default teamRankInfos;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface TeamRankInfoType {
   rank: number;
   name: string;
   description: string;
+  url: string;
   gardenInfos: GardenInfoType[];
 }
 


### PR DESCRIPTION
### 관련 이슈
- close #123 

### 작업 요약
- 팀 카드 반응형으로 만들었습니다.
- 팀 카드 클릭시 해당 팀의 url 로 redirect 되도록 설정했습니다.

### 리뷰 요구 사항
- 여러분의 화면에서도 괜찮은지 확인 부탁드립니다.
- `p={4}, p="4", p="16px"`이 사항 관련으로 제가 안 지킨 문법이 있는지 확인 부탁드립니다.
- 리뷰 예상 시간 : `5분`
