### PR TITLE
Feature/#142 팀페이지에서 텃밭 렌더링

### DIFF
--- a/src/app/team/[teamId]/page.tsx
+++ b/src/app/team/[teamId]/page.tsx
@@ -32,7 +32,7 @@ const Page = () => {
 
       <Flex pos="relative" align="center" flex="1" gap="8">
         {/* TODO  잔디 */}
-        <Box pos="relative" overflow="hidden" w="100%" h={{ base: '250px', md: '300px' }}>
+        <Box pos="relative" overflow="hidden" w="100%" h={{ base: '250px', md: '300px', xl: '320px' }}>
           <Box pos="absolute" w="100%" h="100%">
             <Garden3D
               rotate


### PR DESCRIPTION
### 관련 이슈
- close #142 

### 작업 요약
- 화면의 너비가 1300px 보다 클때, 텃밭을 돌리면 화면을 넘쳐 잘리는 부분이 발생했습니다.
이 부분 고쳤습니다.


### 리뷰 요구 사항
- @pipisebastian 님이 너무 잘해놓으셔서 뭘 더 고치면 좋을 지 모르겠습니다
- 다들 한번 확인해봐주시고 이상한 점 알려주세요!
- 리뷰 예상 시간 : `1분`