### PR TITLE
Feature/#171 레이아웃 높이 짤리는 부분 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,15 +14,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
         <Providers>
           <Flex w="100vw" maxW="100vw" minH="100vh">
             <Sidebar />
-            <Box flex="1">
-              <Box pos="relative" w="100%" h="100%">
-                <Box pos="absolute" w="inherit" h="100%">
-                  <Box pos="relative" w="100%" h="100%">
-                    {children}
-                  </Box>
-                </Box>
-              </Box>
-            </Box>
+            <Box flex="1">{children}</Box>
           </Flex>
         </Providers>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Text, Flex } from '@chakra-ui/react';
+import { Text, Flex, Box } from '@chakra-ui/react';
 import { useRef } from 'react';
 
 import CropLine from '@/containers/main/CropLine';
@@ -16,55 +16,61 @@ const Page = () => {
   const mainSectionRef = useRef<MainSectionElement>(null);
 
   return (
-    <MainSection ref={mainSectionRef}>
-      <Flex key="title_with_login" pos="relative" justify="center" h="100vh" bgColor="green_dark">
-        <Flex
-          key="title_with_login"
-          justify={{ base: 'center', md: 'space-between' }}
-          w="100%"
-          h="100%"
-          mx={{ base: '0', md: '5%', '2xl': '8%' }}
-        >
-          <Flex
-            justify="center"
-            direction="column"
-            w={{ base: '480px', lg: '680px', '2xl': '960px' }}
-            h="100%"
-            textColor="white"
-          >
-            <Text textStyle="title_xl">DOORE</Text>
-            <Text textStyle="title_md" mb="2" whiteSpace="nowrap">
-              community for developer
-            </Text>
-            <Text textStyle="title_sm" mb="4">
-              Investigators have raided the home of the teenage suspect behind the physical attack on ruling party
-              lawmaker Bae Hyun-jin as police are trying to determine the exact motive of the...
-            </Text>
-            <GoogleLoginButton />
-          </Flex>
-          <Flex columnGap={{ base: '6', lg: '8', '2xl': '10' }} display={{ base: 'none', md: 'flex' }} h="100%">
-            <CropLine />
-            <CropLine reverse />
-          </Flex>
-        </Flex>
-        <ScrollDownButton onClick={() => mainSectionRef.current?.scrollNext()} />
-      </Flex>
+    <Box pos="relative" w="100%" h="100%">
+      <Box pos="absolute" w="inherit" h="100%">
+        <Box pos="relative" w="100%" h="100%">
+          <MainSection ref={mainSectionRef}>
+            <Flex key="title_with_login" pos="relative" justify="center" h="100vh" bgColor="green_dark">
+              <Flex
+                key="title_with_login"
+                justify={{ base: 'center', md: 'space-between' }}
+                w="100%"
+                h="100%"
+                mx={{ base: '0', md: '5%', '2xl': '8%' }}
+              >
+                <Flex
+                  justify="center"
+                  direction="column"
+                  w={{ base: '480px', lg: '680px', '2xl': '960px' }}
+                  h="100%"
+                  textColor="white"
+                >
+                  <Text textStyle="title_xl">DOORE</Text>
+                  <Text textStyle="title_md" mb="2" whiteSpace="nowrap">
+                    community for developer
+                  </Text>
+                  <Text textStyle="title_sm" mb="4">
+                    Investigators have raided the home of the teenage suspect behind the physical attack on ruling party
+                    lawmaker Bae Hyun-jin as police are trying to determine the exact motive of the...
+                  </Text>
+                  <GoogleLoginButton />
+                </Flex>
+                <Flex columnGap={{ base: '6', lg: '8', '2xl': '10' }} display={{ base: 'none', md: 'flex' }} h="100%">
+                  <CropLine />
+                  <CropLine reverse />
+                </Flex>
+              </Flex>
+              <ScrollDownButton onClick={() => mainSectionRef.current?.scrollNext()} />
+            </Flex>
 
-      <Flex
-        key="main"
-        pos="relative"
-        align="center"
-        direction="column"
-        overflow="hidden"
-        w="100%"
-        h="100vh"
-        whiteSpace="nowrap"
-      >
-        <TeamRankBG />
-        <TeamRankDescription />
-        <TeamRankSlider />
-      </Flex>
-    </MainSection>
+            <Flex
+              key="main"
+              pos="relative"
+              align="center"
+              direction="column"
+              overflow="hidden"
+              w="100%"
+              h="100vh"
+              whiteSpace="nowrap"
+            >
+              <TeamRankBG />
+              <TeamRankDescription />
+              <TeamRankSlider />
+            </Flex>
+          </MainSection>
+        </Box>
+      </Box>
+    </Box>
   );
 };
 


### PR DESCRIPTION

### 관련 이슈
- close #171
![image](https://github.com/BDD-CLUB/01-doo-re-front/assets/81643702/1f22873a-36a5-40cd-a920-48d4c4ab398b)

### 작업 요약

- 메인페이지에서 쓰이는 레이아웃을 메인페이지 파일로 뺐습니다


### 리뷰 요구 사항

- 0.1분
