### PR TITLE
Feature/#169 스터디 진행률 반응형 적용

### DIFF
--- a/src/app/team/[teamId]/study/[studyId]/page.tsx
+++ b/src/app/team/[teamId]/study/[studyId]/page.tsx
@@ -14,7 +14,7 @@ const sampleStudy = studyCardData[0];
 
 const Page = () => {
   return (
-    <Grid alignItems="center" gap="9" w="100%" p="8">
+    <Flex align="center" direction="column" gap="9" w="100%" p="8">
       <Flex justify="space-between" w="100%">
         <Title name={sampleStudy.name} description={sampleStudy.description} />
         <StudyInfoCard
@@ -44,7 +44,7 @@ const Page = () => {
           <Participant participantInfos={participantData} />
         </Flex>
       </Grid>
-    </Grid>
+    </Flex>
   );
 };
 

--- a/src/containers/study/StudyInfoCard/index.tsx
+++ b/src/containers/study/StudyInfoCard/index.tsx
@@ -9,7 +9,7 @@ const StudyInfoCard = ({ progress, startAt, endAt }: StudyInfoCardProps) => {
 
   return (
     <Card p="4" bg="white" borderRadius="lg">
-      <Flex columnGap={{ base: '0', '2xl': '4' }} fontWeight="bold">
+      <Flex columnGap="4" fontWeight="bold">
         <Text display={{ base: 'none', '2xl': 'block' }}>스터디 진행률</Text>
         <StudyProgress progress={progress} />
         <Text display={{ base: 'none', '2xl': 'block' }} ml="auto">

--- a/src/containers/study/StudyInfoCard/index.tsx
+++ b/src/containers/study/StudyInfoCard/index.tsx
@@ -10,9 +10,9 @@ const StudyInfoCard = ({ progress, startAt, endAt }: StudyInfoCardProps) => {
   return (
     <Card p="4" bg="white" borderRadius="lg">
       <Flex columnGap={{ base: '0', '2xl': '4' }} fontWeight="bold">
-        <Text display={{ base: 'none', lg: 'none', '2xl': 'block' }}>스터디 진행률</Text>
+        <Text display={{ base: 'none', '2xl': 'block' }}>스터디 진행률</Text>
         <StudyProgress progress={progress} />
-        <Text display={{ base: 'none', lg: 'none', '2xl': 'block' }} ml="auto">
+        <Text display={{ base: 'none', '2xl': 'block' }} ml="auto">
           스터디 기간
         </Text>
         <Text display={{ base: 'none', md: 'block' }}>


### PR DESCRIPTION
### 관련 이슈
- close #169 

### 작업 요약
- 화면의 너비가 줄어들 때, 스터디 소개글과 커리큘럼 사이의 간격이 일정했다가 커졌다가 줄어드는 것이 불편해서 수정했습니다.
- Text 요소에 원래는 textStyle을 넣어야하지만, 너비가 '2xl'이상일때만 보이도록 설정해두어서 넘어갔습니다.
- 기존의 진행률 box와 기간 사이의 gap을 넣어주었습니다. 

### 리뷰 요구 사항
- 리뷰 예상 시간: `5분`
