### PR TITLE
Feature/#175 인풋 필드 테마 적용

### DIFF
--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,9 +1,11 @@
 import Avatar from './avatar';
 import Button from './button';
+import Input from './input';
 
 const components = {
   Avatar,
   Button,
+  Input,
 };
 
 export default components;

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,11 +1,13 @@
 import Avatar from './avatar';
 import Button from './button';
 import Input from './input';
+import Textarea from './textarea';
 
 const components = {
   Avatar,
   Button,
   Input,
+  Textarea,
 };
 
 export default components;

--- a/src/theme/components/input.ts
+++ b/src/theme/components/input.ts
@@ -1,0 +1,26 @@
+import { inputAnatomy } from '@chakra-ui/anatomy';
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react';
+
+const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(inputAnatomy.keys);
+
+const Input = defineMultiStyleConfig({
+  defaultProps: {
+    variant: 'default',
+  },
+
+  variants: {
+    default: definePartsStyle({
+      field: {
+        bg: 'orange_light',
+        color: 'white',
+        rounded: '3xl',
+        _focus: {
+          borderColor: 'orange',
+          bg: 'orange',
+        },
+      },
+    }),
+  },
+});
+
+export default Input;

--- a/src/theme/components/textarea.ts
+++ b/src/theme/components/textarea.ts
@@ -1,0 +1,21 @@
+import { defineStyleConfig } from '@chakra-ui/react';
+
+const Textarea = defineStyleConfig({
+  defaultProps: {
+    variant: 'default',
+  },
+
+  variants: {
+    default: {
+      bg: 'orange_light',
+      color: 'white',
+      rounded: '3xl',
+      _focus: {
+        borderColor: 'orange',
+        bg: 'orange',
+      },
+    },
+  },
+});
+
+export default Textarea;


### PR DESCRIPTION
### 관련 이슈

- #175 

### 작업 요약

- input, textarea 테마 적용했습니다. 기본으로 오렌지색 적용시켰습니다. 테마명을 `default`로 하는거 괜찮을까용?

### 작업 상세 설명
- ✅ input은 다음과 같이 사용하면 됩니다. 따로 props넣을 필요 x
```ts
<Input />
```
- ✅ textarea의 경우, 저번에 만들어둔 autoResizeTextArea를 쓰자!라고 말씀드렸었는데.. 생각해보니까 자동으로 크게해주는게. 정말 필요할때가 아니면 안쓰는게 좋을 것 같더라구요! (ref 써줘야 하기 때문)
- ⭐️ 그래서 특별한 경우가 아니면, 이렇게 보여주는 높이를 `rows`로 아예 고정시키는거 어떨까요? + `resize`도 none으로 둬야합니다! (내용 길어지면 알아서 스크롤 가능함!)
```tsx
   <Textarea resize="none" rows={4} />
```
   
- ✅ input의 경우 InputGroup을 사용해서 좌,우에 아이콘 버튼을 둘 수 있는데. [링크참고](https://chakra-ui.com/docs/components/input#left-and-right-addons)
```tsx
<InputGroup>
  <InputLeftElement>
    <IconButton />
  </InputLeftElement>
  <Input />
  <InputRightElement>
    <IconButton />
  </InputRightElement>
</InputGroup>
```
- 근데 지금 사실, icon을 테마를 지정해뒀는데, 이게 저는 shadow가 대부분 들어갈 줄 알았는데, 은근히 안 들어가는게 많더라구요.. 게다가 배경색도 안들어가는게 많아서.. 어떻게 테마를 나눠야할지 고민중입니다...   

- ✅ textarea의 경우, 아이콘을 따로 못둡니다... chakra에서 제공해주는 것도 없더라구용.. 그런데 textarea에 아이콘이 들어가는게 커리큘럼을 제외하면 없는것 같더라구요! 그래서 일단 ref를 사용하는 textarea(`autoResizeTextarea`) 에다가, 좌, 우 아이콘을 넣을 수 있도록 커스텀하는 중입니다..! 혹시나 추후에 ref를 사용안하는 textarea에 좌우 아이콘이 필요하다고하면.. 그때 만들겠습니다!
<img width="547" alt="image" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/81643702/3d34d527-5254-4139-a98c-87a6372f2db4">



### 리뷰 요구 사항

- 1분

## 미리보기
<img width="580" alt="image" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/81643702/0ddccaa1-4dfd-4e45-93fe-6ac43659a72f">