### PR TITLE
Feature/#177 radio component

### DIFF
--- a/src/components/StyledRadio/index.tsx
+++ b/src/components/StyledRadio/index.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/jsx-props-no-spreading */
+
+'use client';
+
+import { Box, useRadio, Flex, Text } from '@chakra-ui/react';
+
+import { StyledRadioProps } from '@/components/StyledRadio/types';
+import color from '@/constants/color';
+import textStyles from '@/theme/foundations/textStyles';
+
+const StyledRadio = (props: StyledRadioProps) => {
+  const { getInputProps, getRadioProps } = useRadio(props);
+  const input = getInputProps();
+  const checkbox = getRadioProps();
+
+  return (
+    <Flex as="label" align="center" w="100%" h={12}>
+      <input {...input} />
+      <Flex
+        {...checkbox}
+        align="center"
+        justify="center"
+        w={6}
+        h={6}
+        mr={3}
+        borderWidth="3px"
+        borderColor={color.orange_light}
+        borderRadius="full"
+        _checked={{
+          borderColor: color.orange,
+        }}
+        aspectRatio="1/1"
+      >
+        <Box
+          {...checkbox}
+          display="none"
+          w={3}
+          h={3}
+          borderRadius="full"
+          _checked={{
+            display: 'block',
+          }}
+          bgColor={color.orange}
+        />
+      </Flex>
+      <Flex
+        {...checkbox}
+        align="center"
+        w="100%"
+        h="100%"
+        borderRadius="3xl"
+        _checked={{
+          bgColor: color.orange,
+        }}
+        bgColor={color.orange_light}
+      >
+        <Text p="3" textColor="white" {...textStyles.bold_xl}>
+          {props.children}
+        </Text>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default StyledRadio;

--- a/src/components/StyledRadio/types.ts
+++ b/src/components/StyledRadio/types.ts
@@ -1,0 +1,5 @@
+import { UseRadioProps } from '@chakra-ui/react';
+
+export interface StyledRadioProps extends UseRadioProps {
+  children: string;
+}

--- a/src/components/StyledRadioGroup/index.tsx
+++ b/src/components/StyledRadioGroup/index.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
+'use client';
+
+import { Flex, HStack, useRadioGroup, Text } from '@chakra-ui/react';
+
+import { StyledRadioGroupProps } from '@/components/StyledRadioGroup/types';
+import textStyles from '@/theme/foundations/textStyles';
+
+const StyledRadioGroup = ({ title, name, defaultValue, value, onChange, children, w }: StyledRadioGroupProps) => {
+  if (defaultValue && children.find((child) => child.props.value === defaultValue) === undefined) {
+    throw new Error('기본값이 선택지에 없습니다.');
+  }
+
+  const { getRootProps, getRadioProps } = useRadioGroup({
+    name,
+    defaultValue,
+    value,
+    onChange,
+  });
+
+  const group = getRootProps();
+
+  return (
+    <Flex direction="column" rowGap="3" w={w} m="20">
+      <Text {...textStyles.bold_xl}>{title}</Text>
+      <HStack {...group}>
+        {children.map((child) => (
+          <child.type key={child.props.value} {...getRadioProps({ value: child.props.value })}>
+            {child.props.children}
+          </child.type>
+        ))}
+      </HStack>
+    </Flex>
+  );
+};
+
+export default StyledRadioGroup;

--- a/src/components/StyledRadioGroup/types.ts
+++ b/src/components/StyledRadioGroup/types.ts
@@ -1,0 +1,9 @@
+export interface StyledRadioGroupProps {
+  title?: string;
+  name?: string;
+  onChange?: (value: string) => void;
+  w?: string | number;
+  defaultValue?: string;
+  value?: string;
+  children: JSX.Element[];
+}


### PR DESCRIPTION
### 관련 이슈

- close #177 

### 작업 요약

스타일이 적용된 Radio 컴포넌트 입니다

### 작업 상세 설명

- 기존 Chakra의 RadioGroup/Radio 와 유사하게 작동합니다.
- StyledRadio : 선택지
- StyledRadioGroup : Radio

### 리뷰 요구 사항

- 리뷰 예상 시간 : 10분
- chakra 문서를 참고하다보니 spread 연산자 사용과 props로 받아오는 등 eslint에 어긋나는 코드가 추가되었는데, 괜찮을지 확인 부탁드립니다. 예외 처리는 했습니다.

### 미리 보기
<img width="575" alt="스크린샷 2024-03-28 오후 1 03 49" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/51306225/51511e61-74e3-4bd7-86bc-5a3109149e26">

예시 코드
```typescript
'use client';

import StyledRadio from '@/components/StyledRadio';
import StyledRadioGroup from '@/components/StyledRadioGroup';

const Page = () => {
  return (
    <>
      <StyledRadioGroup w="500px" title="파일 유형" defaultValue="img">
        <StyledRadio value="img">이미지</StyledRadio>
        <StyledRadio value="file">파일</StyledRadio>
        <StyledRadio value="url">URL 링크</StyledRadio>
      </StyledRadioGroup>
      <StyledRadioGroup w="500px" title="공개 범위" defaultValue="all">
        <StyledRadio value="all">전체 공개</StyledRadio>
        <StyledRadio value="only_study">스터디 공개</StyledRadio>
      </StyledRadioGroup>
    </>
  );
};

export default Page;
```
