### PR TITLE
Feature/#181 Selector 구현

### DIFF
--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -32,7 +32,7 @@ const Selector = ({ placeholder, label }: SelectorProps) => {
         >
           <Text textStyle="bold_md">{placeholder}</Text>
         </MenuButton>
-        <MenuList minW={boxWidth} bg="orange_light" borderColor="orange_light" borderRadius="xl">
+        <MenuList overflow="hidden" minW={boxWidth} bg="orange_light" borderColor="orange_light" borderRadius="3xl">
           {label.map((item) => (
             <MenuItem key={item} color="white" bg="orange_light" _hover={{ bg: 'orange_dark' }}>
               <Text textStyle="bold_md">{item}</Text>

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -33,8 +33,8 @@ const Selector = ({ placeholder, label }: SelectorProps) => {
         <Text textStyle="bold_md">{placeholder}</Text>
       </MenuButton>
       <MenuList overflow="hidden" minW={menuWidth} bg="orange_light" borderColor="orange_light" borderRadius="3xl">
-        {label.map((item) => (
-          <MenuItem key={item} color="white" bg="orange_light" _hover={{ bg: 'orange_dark' }}>
+        {label.map((item, index) => (
+          <MenuItem key={item} color="white" bg="orange_light" _hover={{ bg: 'orange_dark' }} value={index}>
             <Text textStyle="bold_md">{item}</Text>
           </MenuItem>
         ))}

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -1,46 +1,45 @@
 'use client';
 
-import { Menu, MenuButton, MenuItem, MenuList, Button, Box, Text } from '@chakra-ui/react';
+import { Menu, MenuButton, MenuItem, MenuList, Button, Text } from '@chakra-ui/react';
 import { useRef, useEffect, useState } from 'react';
 import { BiChevronDown } from 'react-icons/bi';
 
 import { SelectorProps } from './types';
 
 const Selector = ({ placeholder, label }: SelectorProps) => {
-  const boxRef = useRef<HTMLDivElement>(null);
-  const [boxWidth, setBoxWidth] = useState('0px');
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuWidth, setMenuWidth] = useState('0px');
 
   useEffect(() => {
-    if (boxRef.current) {
-      setBoxWidth(`${boxRef.current.offsetWidth}px`);
+    if (menuRef.current) {
+      setMenuWidth(`${menuRef.current.offsetWidth}px`);
     }
   }, []);
 
   return (
-    <Box ref={boxRef} w="100%">
-      <Menu>
-        <MenuButton
-          as={Button}
-          w="100%"
-          color="white"
-          textAlign="left"
-          bg="orange_light"
-          _hover={{ bg: 'orange_light' }}
-          _active={{ bg: 'orange_light' }}
-          _focus={{ bg: 'orange_light' }}
-          rightIcon={<BiChevronDown />}
-        >
-          <Text textStyle="bold_md">{placeholder}</Text>
-        </MenuButton>
-        <MenuList overflow="hidden" minW={boxWidth} bg="orange_light" borderColor="orange_light" borderRadius="3xl">
-          {label.map((item) => (
-            <MenuItem key={item} color="white" bg="orange_light" _hover={{ bg: 'orange_dark' }}>
-              <Text textStyle="bold_md">{item}</Text>
-            </MenuItem>
-          ))}
-        </MenuList>
-      </Menu>
-    </Box>
+    <Menu>
+      <MenuButton
+        ref={menuRef}
+        as={Button}
+        w="100%"
+        color="white"
+        textAlign="left"
+        bg="orange_light"
+        _hover={{ bg: 'orange_light' }}
+        _active={{ bg: 'orange_light' }}
+        _focus={{ bg: 'orange_light' }}
+        rightIcon={<BiChevronDown />}
+      >
+        <Text textStyle="bold_md">{placeholder}</Text>
+      </MenuButton>
+      <MenuList overflow="hidden" minW={menuWidth} bg="orange_light" borderColor="orange_light" borderRadius="3xl">
+        {label.map((item) => (
+          <MenuItem key={item} color="white" bg="orange_light" _hover={{ bg: 'orange_dark' }}>
+            <Text textStyle="bold_md">{item}</Text>
+          </MenuItem>
+        ))}
+      </MenuList>
+    </Menu>
   );
 };
 

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Menu, MenuButton, MenuItem, MenuList, Button, Box, Text } from '@chakra-ui/react';
+import { useRef, useEffect, useState } from 'react';
+import { BiChevronDown } from 'react-icons/bi';
+
+import { SelectorProps } from './types';
+
+const Selector = ({ placeholder, label }: SelectorProps) => {
+  const boxRef = useRef<HTMLDivElement>(null);
+  const [boxWidth, setBoxWidth] = useState('0px');
+
+  useEffect(() => {
+    if (boxRef.current) {
+      setBoxWidth(`${boxRef.current.offsetWidth}px`);
+    }
+  }, []);
+
+  return (
+    <Box ref={boxRef} w="100%">
+      <Menu>
+        <MenuButton
+          as={Button}
+          w="100%"
+          color="white"
+          textAlign="left"
+          bg="orange_light"
+          _hover={{ bg: 'orange_light' }}
+          _active={{ bg: 'orange_light' }}
+          _focus={{ bg: 'orange_light' }}
+          rightIcon={<BiChevronDown />}
+        >
+          <Text textStyle="bold_md">{placeholder}</Text>
+        </MenuButton>
+        <MenuList minW={boxWidth} bg="orange_light" borderColor="orange_light" borderRadius="xl">
+          {label.map((item) => (
+            <MenuItem key={item} color="white" bg="orange_light" _hover={{ bg: 'orange_dark' }}>
+              <Text textStyle="bold_md">{item}</Text>
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Menu>
+    </Box>
+  );
+};
+
+export default Selector;

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -32,9 +32,16 @@ const Selector = ({ placeholder, label }: SelectorProps) => {
       >
         <Text textStyle="bold_md">{placeholder}</Text>
       </MenuButton>
-      <MenuList overflow="hidden" minW={menuWidth} bg="orange_light" borderColor="orange_light" borderRadius="3xl">
+      <MenuList
+        overflow="hidden"
+        minW={menuWidth}
+        p="0"
+        bg="orange_light"
+        borderColor="orange_light"
+        borderRadius="3xl"
+      >
         {label.map((item, index) => (
-          <MenuItem key={item} color="white" bg="orange_light" _hover={{ bg: 'orange_dark' }} value={index}>
+          <MenuItem key={item} pl="15" color="white" bg="orange_light" _hover={{ bg: 'orange_dark' }} value={index}>
             <Text textStyle="bold_md">{item}</Text>
           </MenuItem>
         ))}

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -28,7 +28,7 @@ const Selector = ({ placeholder, label }: SelectorProps) => {
         _hover={{ bg: 'orange_light' }}
         _active={{ bg: 'orange_light' }}
         _focus={{ bg: 'orange_light' }}
-        rightIcon={<BiChevronDown />}
+        rightIcon={<BiChevronDown size="28px" />}
       >
         <Text textStyle="bold_md">{placeholder}</Text>
       </MenuButton>

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -6,7 +6,7 @@ import { BiChevronDown } from 'react-icons/bi';
 
 import { SelectorProps } from './types';
 
-const Selector = ({ placeholder, label }: SelectorProps) => {
+const Selector = ({ selected, label, handleSelector }: SelectorProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
   const [menuWidth, setMenuWidth] = useState('0px');
 
@@ -30,7 +30,7 @@ const Selector = ({ placeholder, label }: SelectorProps) => {
         _focus={{ bg: 'orange_light' }}
         rightIcon={<BiChevronDown size="28px" />}
       >
-        <Text textStyle="bold_md">{placeholder}</Text>
+        <Text textStyle="bold_md">{selected}</Text>
       </MenuButton>
       <MenuList
         overflow="hidden"
@@ -41,7 +41,15 @@ const Selector = ({ placeholder, label }: SelectorProps) => {
         borderRadius="3xl"
       >
         {label.map((item, index) => (
-          <MenuItem key={item} pl="15" color="white" bg="orange_light" _hover={{ bg: 'orange_dark' }} value={index}>
+          <MenuItem
+            key={item}
+            pl="15"
+            color="white"
+            bg="orange_light"
+            _hover={{ bg: 'orange_dark' }}
+            onClick={() => handleSelector(item)}
+            value={index}
+          >
             <Text textStyle="bold_md">{item}</Text>
           </MenuItem>
         ))}

--- a/src/components/Selector/types.ts
+++ b/src/components/Selector/types.ts
@@ -1,0 +1,4 @@
+export interface SelectorProps {
+  placeholder: string;
+  label: string[];
+}

--- a/src/components/Selector/types.ts
+++ b/src/components/Selector/types.ts
@@ -1,5 +1,5 @@
 export interface SelectorProps {
-  selected: string | undefined;
+  selected: string;
   label: string[];
   handleSelector: (data: string) => void;
 }

--- a/src/components/Selector/types.ts
+++ b/src/components/Selector/types.ts
@@ -1,4 +1,5 @@
 export interface SelectorProps {
-  placeholder: string;
+  selected: string | undefined;
   label: string[];
+  handleSelector: (data: string) => void;
 }

--- a/src/mocks/selector.ts
+++ b/src/mocks/selector.ts
@@ -1,0 +1,8 @@
+import { SelectorProps } from '@/components/Selector/types';
+
+const selectorData: SelectorProps = {
+  placeholder: '작물을 선택해주세요',
+  label: ['토마토', '고구마', '당근', '완두콩', '벼'],
+};
+
+export default selectorData;

--- a/src/mocks/selector.ts
+++ b/src/mocks/selector.ts
@@ -1,8 +1,0 @@
-import { SelectorProps } from '@/components/Selector/types';
-
-const selectorData: SelectorProps = {
-  placeholder: '작물을 선택해주세요',
-  label: ['토마토', '고구마', '당근', '완두콩', '벼'],
-};
-
-export default selectorData;


### PR DESCRIPTION
### 관련 이슈

- close #181

### 작업 요약

-  Chakra UI의 Menu를 활용하여 Selector 컴포넌트를 구현하였습니다.

### 작업 상세 설명

- 처음엔 Selector의 필드 디자인을 변경하는 것으로 시작하였으나, option은 따로 커스터마이징이 불가능하여 비슷한 Menu 컴포넌트를 활용해 제작하였습니다.
- MenuList은 `position: absolute`을 자체적으로 가지고 있어 `w="100%"(minW 포함)`이 적용이 되지 않기에 훅을 이용하여 너비를 가져와 적용하는 걸로 대체했습니다. `position: relative`도 적용이 안 돼서 이 방법 말고도 좋은 방법이 있다면 알려주시면 감사하겠습니다!

### 리뷰 요구 사항

- 피그마에서는 textStyle이 `bold_xl`로 되어있지만, 제가 보기에 너무 크다는 느낌이 들어서 일단 `bold_md`로 해놓긴 했습니다. 피그마대로 바꾸는 게 나을지 아니면 지금 상태가 나은지 의견을 여쭙고 싶습니다!
- 또한, 옵션을 선택할 때 첫 번째 옵션과 마지막 옵션에 마우스를 호버하면 현재는 MenuList와 MenuItem 사이에 틈이 있습니다. 이는 `p=0`으로 두면 틈을 없앨 수 있긴 한데 어떤 것이 좋을지 이것도 의견을 여쭙고 싶습니다!
- 저는 딘님과 다르게 리스트를 넣도록 하였는데... 수정하는 게 좋을까요?😅
```tsx
import { Box } from '@chakra-ui/react';

import Selector from '@/components/Selector';

const Page = () => {
  return (
    <Box w="300px" m="20">
      <Selector placeholder="작물을 선택해주세요" label={['토마토', '고구마', '당근', '완두콩', '벼']} />
    </Box>
  );
};

export default Page;
```
- 리뷰 예상 시간 : 7분

### 미리 보기
#### bold_xl
![스크린샷 2024-03-28 195328](https://github.com/BDD-CLUB/01-doo-re-front/assets/126975394/810ef9ef-b33a-4072-8cf4-764c5c261465)
#### bold_md
![스크린샷 2024-03-28 195208](https://github.com/BDD-CLUB/01-doo-re-front/assets/126975394/9e34d661-e460-4d21-87fb-a970dde81dce)

#### `p=0`이 아닐 때 (bold_md)
![스크린샷 2024-03-28 200204](https://github.com/BDD-CLUB/01-doo-re-front/assets/126975394/b416610c-fa31-4016-97c0-c081c6c87b3b)
#### `p=0`일 때 (bold_md)
![스크린샷 2024-03-28 200212](https://github.com/BDD-CLUB/01-doo-re-front/assets/126975394/d821d3a7-07aa-46c8-bb75-283b6c2e7930)
