### PR TITLE
Feature/#193 radio 컴포넌트 텍스트 사이즈 변경

### DIFF
--- a/src/components/StyledRadio/index.tsx
+++ b/src/components/StyledRadio/index.tsx
@@ -23,7 +23,7 @@ const StyledRadio = (props: StyledRadioProps) => {
         justify="center"
         w={6}
         h={6}
-        mr={3}
+        mr={1}
         borderWidth="3px"
         borderColor={color.orange_light}
         borderRadius="full"

--- a/src/components/StyledRadio/index.tsx
+++ b/src/components/StyledRadio/index.tsx
@@ -55,7 +55,7 @@ const StyledRadio = (props: StyledRadioProps) => {
         }}
         bgColor={color.orange_light}
       >
-        <Text p="3" textColor="white" {...textStyles.bold_xl}>
+        <Text px="6" textColor="white" {...textStyles.bold_md}>
           {props.children}
         </Text>
       </Flex>

--- a/src/components/StyledRadioGroup/index.tsx
+++ b/src/components/StyledRadioGroup/index.tsx
@@ -7,7 +7,16 @@ import { Flex, HStack, useRadioGroup, Text } from '@chakra-ui/react';
 import { StyledRadioGroupProps } from '@/components/StyledRadioGroup/types';
 import textStyles from '@/theme/foundations/textStyles';
 
-const StyledRadioGroup = ({ title, name, defaultValue, value, onChange, children, w }: StyledRadioGroupProps) => {
+const StyledRadioGroup = ({
+  title,
+  name,
+  defaultValue,
+  value,
+  onChange,
+  children,
+  w,
+  spacing,
+}: StyledRadioGroupProps) => {
   if (defaultValue && children.find((child) => child.props.value === defaultValue) === undefined) {
     throw new Error('기본값이 선택지에 없습니다.');
   }
@@ -22,9 +31,9 @@ const StyledRadioGroup = ({ title, name, defaultValue, value, onChange, children
   const group = getRootProps();
 
   return (
-    <Flex direction="column" rowGap="3" w={w} m="20">
+    <Flex direction="column" rowGap="3" w={w}>
       <Text {...textStyles.bold_xl}>{title}</Text>
-      <HStack {...group}>
+      <HStack {...group} spacing={spacing || '4'}>
         {children.map((child) => (
           <child.type key={child.props.value} {...getRadioProps({ value: child.props.value })}>
             {child.props.children}

--- a/src/components/StyledRadioGroup/types.ts
+++ b/src/components/StyledRadioGroup/types.ts
@@ -6,4 +6,5 @@ export interface StyledRadioGroupProps {
   defaultValue?: string;
   value?: string;
   children: JSX.Element[];
+  spacing?: string | number;
 }


### PR DESCRIPTION
### 관련 이슈

- close #193 

### 작업 요약

radio 컴포넌트 텍스트 사이즈 변경 및 세부 디자인 변경

### 작업 상세 설명

- StyledRadioGroup에 spacing을 추가하여 선택지 사이의 거리를 조절할 수 있게 함 ( 기본값 : 4 )
- StyledRadio에서 Dot과 텍스트 사이의 거리를 1로 줄임

### 리뷰 요구 사항

- 리뷰 예상 시간 : 2분