### PR TITLE
Feature/#196 auto resize textarea 아이콘 추가기능 확장

### DIFF
--- a/src/components/AutoResizeTextarea/index.tsx
+++ b/src/components/AutoResizeTextarea/index.tsx
@@ -1,12 +1,45 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { Textarea, forwardRef } from '@chakra-ui/react';
-import React from 'react';
+import { Box, Flex, Textarea, forwardRef } from '@chakra-ui/react';
 import ResizeTextarea from 'react-textarea-autosize';
 
 import { AutoResizeTextareaProps } from './type';
 
-const AutoResizeTextarea = forwardRef(({ ref, ...props }: AutoResizeTextareaProps) => (
-  <Textarea ref={ref} as={ResizeTextarea} overflow="hidden" w="100%" minH="unset" resize="none" {...props} />
-));
+const AutoResizeTextarea = forwardRef(
+  (
+    { value, onChange, LeftIconButton, RightIconButton, ...props }: AutoResizeTextareaProps,
+    ref: React.Ref<HTMLTextAreaElement>,
+  ) => {
+    const rightChildCount = RightIconButton?.props.children?.length ?? 1;
+    const leftChildCount = LeftIconButton?.props.children?.length ?? 1;
 
+    const rightPadding = RightIconButton ? `${38 * rightChildCount}px` : '16px';
+    const leftPadding = LeftIconButton ? `${38 * leftChildCount}px` : '16px';
+
+    return (
+      <Flex pos="relative" w="100%">
+        <Box pos="absolute" zIndex="1" left="0" alignContent="center" h="40px">
+          {LeftIconButton}
+        </Box>
+        <Box w="100%">
+          <Textarea
+            ref={ref}
+            as={ResizeTextarea}
+            w="100%"
+            minH="40px"
+            py="2"
+            pr={rightPadding}
+            pl={leftPadding}
+            resize="none"
+            onChange={onChange}
+            value={value}
+            {...props}
+          />
+        </Box>
+        <Box pos="absolute" zIndex="1" right="0" alignContent="center" h="40px">
+          {RightIconButton}
+        </Box>
+      </Flex>
+    );
+  },
+);
 export default AutoResizeTextarea;

--- a/src/components/AutoResizeTextarea/type.ts
+++ b/src/components/AutoResizeTextarea/type.ts
@@ -1,3 +1,6 @@
 export interface AutoResizeTextareaProps {
-  ref?: React.Ref<HTMLTextAreaElement>;
+  value: string;
+  onChange: React.ChangeEventHandler<HTMLTextAreaElement>;
+  LeftIconButton?: React.ReactElement;
+  RightIconButton?: React.ReactElement;
 }

--- a/src/components/IconBox/index.tsx
+++ b/src/components/IconBox/index.tsx
@@ -4,7 +4,7 @@ import { IconBoxProps } from './type';
 
 const IconBox = ({ leftIcon, content, rightIcon, handleClick }: IconBoxProps) => {
   return (
-    <Flex align="center" gap="1" w="100%" color="white" bg="orange_light" borderRadius="2xl">
+    <Flex align="center" gap="1" w="100%" h="40px" color="white" bg="orange_light" borderRadius="2xl">
       <IconButton as="div" flexShrink="0" aria-label="" icon={leftIcon} size="icon_md" variant="transparent" />
       <Text textStyle="bold_md" flex="auto" isTruncated>
         {content}

--- a/src/theme/components/input.ts
+++ b/src/theme/components/input.ts
@@ -13,11 +13,15 @@ const Input = defineMultiStyleConfig({
       field: {
         bg: 'orange_light',
         color: 'white',
-        rounded: '3xl',
+        rounded: '2xl',
         _focus: {
           borderColor: 'orange',
           bg: 'orange',
         },
+      },
+      element: {
+        h: '40px',
+        w: { base: '34px', lg: '36px', '2xl': '38px' },
       },
     }),
   },

--- a/src/theme/components/textarea.ts
+++ b/src/theme/components/textarea.ts
@@ -9,7 +9,7 @@ const Textarea = defineStyleConfig({
     default: {
       bg: 'orange_light',
       color: 'white',
-      rounded: '3xl',
+      rounded: '2xl',
       _focus: {
         borderColor: 'orange',
         bg: 'orange',


### PR DESCRIPTION
### 관련 이슈

- close #196

### 작업 요약

- auto resize textarea 아이콘 추가 기능 확장 (양옆 여러개 추가 가능. 추가됨에 따라 텍스트 양옆에 padding 넣어줬습니다.)
- 높이는 **차크라 기본 input**의 높이 40px로 통일시켜줬습니다.
- **rounded** 2xl로 통일 (input, textfield, iconBox)

### 작업 상세 설명

- 차크라 ui에서 제공하는거는 앙옆 아이콘을 담는 element(`InputRightElement`,`InputLeftElement`)가 반응형 없이 40px이지만, 우리가 만든 icon_md는 반응형이 존재합니다. 이에 차크라 컴포넌트에 테마로 반응형을 넣어줬습니다([참고링크1](https://chakra-ui.com/docs/components/input/theming#adding-a-custom-variant) [참고링크2](https://github.com/chakra-ui/chakra-ui/issues/3119))
```ts
        <InputGroup>
          <Input value="인풋 컴포넌트 (차크라 제공)" />
          <InputRightElement> // 이거 자체가 40px를 잡아먹어서, 내부 요소인 IconButton이 반응형이더라도 40px를 유지하더라구요. 
             //그런데 이 element 테마를 수정할 수 있어서 거기서 반응형을 해줬습니다
            <IconButton aria-label="add" icon={<BiTrash />} onClick={() => {}} size="icon_md" variant="transparent" />
          </InputRightElement>
        </InputGroup>
```

- 그리고 사실 auto resize text area의 경우, 추가한 아이콘 크기 만큼 양옆으로 패딩을 줘야하는데요(text칸을 작게 만들어야하는데) 사실 아이콘 크기가 반응형인 만큼, 패딩 크기로 34,36,38로 반응형으로 계산해야하는데.. 그거까진 티가 안나고, 조금 투머치..하다 생각해서 안해줬습니닷! 그치만 하라고 하신다면 하겠습니다..

- 아이콘이 없을경우에는, (차크라 input의) 텍스트 패딩이 16px이길래 똑같이 맞춰줬습니다.

### 리뷰 요구 사항

- 4분
- 추가적으로, 현재 첨부파일 공통 컴포넌트인 `iconBox`는 `bold_md`이던데, 저번에 bold를 다 빼기로 했던 것 같은데, `iconBox`도 똑같이 빼면 될까요??
- 디자인은 다 맞췄다고 생각이 드는데, 놓친 부분이 있으면 말씀부탁드립니다!

### 미리 보기

<img width="504" alt="image" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/81643702/554eb8a8-366c-4281-b709-9bf976b5bb9e">

### 예시코드
```ts
                      const ref = React.useRef<HTMLTextAreaElement>();
                      // 중략              
                      <AutoResizeTextarea
                        ref={ref}
                        value={data.content}
                        onChange={() => {}}
                        LeftIconButton={ // iconbutton은 element 하나만 던져줘도 되고
                          <IconButton
                            aria-label="add"
                            icon={<BiEdit />}
                            onClick={() => {}}
                            size="icon_md"
                            variant="transparent"
                          />
                        }
                        RightIconButton={  // iconbutton은 fragment로 여러개 감싸서 던져줘도 됩니다
                          <>
                            <IconButton
                              aria-label="add"
                              icon={<BiEdit />}
                              onClick={() => {}}
                              size="icon_md"
                              variant="transparent"
                            />
                            <IconButton
                              aria-label="add"
                              icon={<BiTrash />}
                              onClick={() => { }}
                              size="icon_md"
                              variant="transparent"
                            />
                          </>
                        }
                      />
```

```ts
        // 기본 text area
        <Textarea resize="none" rows={1} />
        // 기본 input (양옆 버튼 존재)
        <InputGroup>
          <Input value="인풋 컴포넌트 (차크라 제공)" />
          <InputRightElement>
            <IconButton aria-label="add" icon={<BiTrash />} onClick={() => {}} size="icon_md" variant="transparent" />
          </InputRightElement>
        </InputGroup>
        // 첨부파일 공통 컴포넌트
        <IconBox
          leftIcon={<BiTrash />}
          content="첨부파일 공통 컴포넌트"
          rightIcon={<BiTrash />}
          handleClick={() => {}}
```