### PR TITLE
Feature/#186 팀 생성 모달 구현

### DIFF
--- a/src/components/IconBox/index.tsx
+++ b/src/components/IconBox/index.tsx
@@ -6,7 +6,7 @@ const IconBox = ({ leftIcon, content, rightIcon, handleClick }: IconBoxProps) =>
   return (
     <Flex align="center" gap="1" w="100%" color="white" bg="orange_light" borderRadius="2xl">
       <IconButton as="div" flexShrink="0" aria-label="" icon={leftIcon} size="icon_md" variant="transparent" />
-      <Text textStyle="bold_md" flex="auto" isTruncated>
+      <Text textStyle="bold_md" flex="auto" cursor="default" isTruncated>
         {content}
       </Text>
       {rightIcon && (

--- a/src/components/Sidebar/CreateTeamModal/index.tsx
+++ b/src/components/Sidebar/CreateTeamModal/index.tsx
@@ -25,6 +25,15 @@ const CreateTeamModal = ({ isOpen, setIsOpen }: CreateTeamModalProps) => {
   const [alertName, setAlertName] = useState<boolean>(false);
   const [alertDescription, setAlertDescription] = useState<boolean>(false);
 
+  const onClose = () => {
+    setName('');
+    setDescription('');
+    setThumbnail(null);
+    setAlertName(false);
+    setAlertDescription(false);
+    setIsOpen(false);
+  };
+
   const onSave = () => {
     if (!alertName && !alertDescription) {
       // TODO - API 연결
@@ -35,10 +44,10 @@ const CreateTeamModal = ({ isOpen, setIsOpen }: CreateTeamModalProps) => {
   return (
     <ActionModal
       isOpen={isOpen}
-      onClose={() => setIsOpen(false)}
+      onClose={onClose}
       title="팀 생성"
       subButtonText="취소"
-      onSubButtonClick={() => setIsOpen(false)}
+      onSubButtonClick={onClose}
       mainButtonText="저장"
       onMainButtonClick={onSave}
     >

--- a/src/components/Sidebar/CreateTeamModal/index.tsx
+++ b/src/components/Sidebar/CreateTeamModal/index.tsx
@@ -35,7 +35,9 @@ const CreateTeamModal = ({ isOpen, setIsOpen }: CreateTeamModalProps) => {
   };
 
   const onSave = () => {
-    if (!alertName && !alertDescription) {
+    if (name === '') setAlertName(true);
+    else if (description === '') setAlertDescription(true);
+    else {
       // TODO - API 연결
       setIsOpen(false);
     }

--- a/src/components/Sidebar/CreateTeamModal/index.tsx
+++ b/src/components/Sidebar/CreateTeamModal/index.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { Flex, Text, Textarea, Image } from '@chakra-ui/react';
+import { useRef, useState } from 'react';
+import { BiEdit, BiFile } from 'react-icons/bi';
+
+import IconBox from '@/components/IconBox';
+import ActionModal from '@/components/Modal/ActionModal';
+
+import { CreateTeamModalProps } from '../type';
+
+const AlertContent = ({ message }: { message: string }) => {
+  return (
+    <Text textStyle="md" color="orange_dark">
+      {message}
+    </Text>
+  );
+};
+
+const CreateTeamModal = ({ isOpen, setIsOpen }: CreateTeamModalProps) => {
+  const inputFileRef = useRef<HTMLInputElement>(null);
+  const [name, setName] = useState<string>('');
+  const [description, setDescription] = useState<string>('');
+  const [thumbnail, setThumbnail] = useState<File | null>();
+  const [alertName, setAlertName] = useState<boolean>(false);
+  const [alertDescription, setAlertDescription] = useState<boolean>(false);
+
+  const onSave = () => {
+    if (!alertName && !alertDescription) {
+      // TODO - API 연결
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <ActionModal
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      title="팀 생성"
+      subButtonText="취소"
+      onSubButtonClick={() => setIsOpen(false)}
+      mainButtonText="저장"
+      onMainButtonClick={onSave}
+    >
+      <Flex direction="column" gap="10" w="100%">
+        <Flex direction="column">
+          <Text textStyle="bold_md">팀 이름</Text>
+          {alertName && <AlertContent message="필수 입력 란입니다." />}
+          <Textarea
+            textStyle="bold_md"
+            _placeholder={{ opacity: 0.7, color: 'white' }}
+            resize="none"
+            onBlur={(e) => {
+              if (e.target.value !== '') setAlertName(false);
+              else setAlertName(true);
+            }}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="팀 이름을 작성해주세요"
+            rows={1}
+            value={name}
+          />
+        </Flex>
+        <Flex direction="column">
+          <Text textStyle="bold_md">팀 소개글</Text>
+          {alertDescription && <AlertContent message="필수 입력 란입니다." />}
+          <Textarea
+            textStyle="bold_md"
+            _placeholder={{ opacity: 0.7, color: 'white' }}
+            resize="none"
+            onBlur={(e) => {
+              if (e.target.value !== '') setAlertDescription(false);
+              else setAlertDescription(true);
+            }}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="팀 소개글을 작성해주세요"
+            rows={6}
+            value={description}
+          />
+        </Flex>
+        <Flex align="center" direction="column">
+          <Text textStyle="bold_md" w="100%">
+            팀 썸네일
+          </Text>
+          <input
+            type="file"
+            accept="image/*"
+            ref={inputFileRef}
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              if (e.target.files && e.target.files[0]) {
+                setThumbnail(e.target.files[0]);
+              }
+            }}
+          />
+          <IconBox
+            leftIcon={<BiFile />}
+            rightIcon={<BiEdit />}
+            content={thumbnail ? thumbnail.name : '파일을 추가해주세요.'}
+            handleClick={() => inputFileRef.current?.click()}
+          />
+          {thumbnail && <Image w="40" alt="thumbnail" src={URL.createObjectURL(thumbnail)} />}
+        </Flex>
+      </Flex>
+    </ActionModal>
+  );
+};
+
+export default CreateTeamModal;

--- a/src/components/Sidebar/SidebarContent/index.tsx
+++ b/src/components/Sidebar/SidebarContent/index.tsx
@@ -14,7 +14,7 @@ import CreateTeamModal from '../CreateTeamModal';
 import { SidebarContentProps } from '../type';
 
 const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
-  const [createTeamModalIsOpen, setCreateTeamModalIsOpen] = useState<boolean>(false);
+  const [isCreateTeamModalOpen, setIsCreateTeamModalOpen] = useState<boolean>(false);
 
   return (
     <>
@@ -68,7 +68,7 @@ const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
                   bg="white"
                   aria-label=""
                   icon={<BsPlus />}
-                  onClick={() => setCreateTeamModalIsOpen(true)}
+                  onClick={() => setIsCreateTeamModalOpen(true)}
                   size="icon_sm"
                 />
               </Flex>
@@ -90,7 +90,7 @@ const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
           </>
         )}
       </Flex>
-      <CreateTeamModal isOpen={createTeamModalIsOpen} setIsOpen={setCreateTeamModalIsOpen} />
+      <CreateTeamModal isOpen={isCreateTeamModalOpen} setIsOpen={setIsCreateTeamModalOpen} />
     </>
   );
 };

--- a/src/components/Sidebar/SidebarContent/index.tsx
+++ b/src/components/Sidebar/SidebarContent/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Avatar, Button, Flex, IconButton, Text } from '@chakra-ui/react';
+import { useState } from 'react';
 import { BiBell, BiUser } from 'react-icons/bi';
 import { BsPlus, BsGrid } from 'react-icons/bs';
 import { MdOutlineLogout } from 'react-icons/md';
@@ -9,75 +10,88 @@ import sidebarData from '@/mocks/sidebar';
 
 import SidebarIconButton from '../Button/SidebarIconButton';
 import Category from '../Category';
+import CreateTeamModal from '../CreateTeamModal';
 import { SidebarContentProps } from '../type';
 
 const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
+  const [createTeamModalIsOpen, setCreateTeamModalIsOpen] = useState<boolean>(false);
+
   return (
-    <Flex pos="sticky" top="0" left="0" direction="column" h="100vh" px={isOpen ? '4' : '2'} py="4" bg="green">
-      <Flex justify={isOpen ? 'space-between' : 'center'} mb="16">
-        {isOpen && (
-          // TODO - 추후 로고 대체
-          <Button as="a" p="0" bg="transparent" _hover={{ bg: 'transparent' }} href="/">
-            <Text textStyle="bold_3xl" color="white">
-              DOO RE
-            </Text>
-          </Button>
-        )}
-        <IconButton
-          minW="0"
-          color="white"
-          fontSize={{
-            base: '28px',
-            lg: '32px',
-            '2xl': '36px',
-          }}
-          bg="transparent"
-          _hover={{ bg: 'transparent' }}
-          aria-label=""
-          icon={<BsGrid />}
-          onClick={() => setIsOpen((prev: boolean) => !prev)}
-        />
-      </Flex>
-      <Flex align="center" direction="column" gap="4" mb="16">
-        <Avatar size={isOpen ? 'lg' : 'md'} src="" />
-        {isOpen && (
-          <Text textStyle="bold_2xl" px="10" py="1" color="white" bg="green_dark" rounded="full">
-            두레
-          </Text>
-        )}
-        <Flex direction={isOpen ? 'row' : 'column'} gap="4">
-          <SidebarIconButton icon={<BiBell />} onClick={() => {}} />
-          <SidebarIconButton icon={<BiUser />} onClick={() => {}} />
-          <SidebarIconButton icon={<MdOutlineLogout />} onClick={() => {}} />
-        </Flex>
-      </Flex>
-      {isOpen && (
-        <>
-          <Flex direction="column" p="4" bg="green_dark" roundedTop="2xl">
-            <Flex align="center" justify="space-between" gap="2">
-              <Text textStyle="bold_xl" color="white" whiteSpace="nowrap">
-                TEAM & STUDY
+    <>
+      <Flex pos="sticky" top="0" left="0" direction="column" h="100vh" px={isOpen ? '4' : '2'} py="4" bg="green">
+        <Flex justify={isOpen ? 'space-between' : 'center'} mb="16">
+          {isOpen && (
+            // TODO - 추후 로고 대체
+            <Button as="a" p="0" bg="transparent" _hover={{ bg: 'transparent' }} href="/">
+              <Text textStyle="bold_3xl" color="white">
+                DOO RE
               </Text>
-              <IconButton color="black" bg="white" aria-label="" icon={<BsPlus />} size="icon_sm" />
+            </Button>
+          )}
+          <IconButton
+            minW="0"
+            color="white"
+            fontSize={{
+              base: '28px',
+              lg: '32px',
+              '2xl': '36px',
+            }}
+            bg="transparent"
+            _hover={{ bg: 'transparent' }}
+            aria-label=""
+            icon={<BsGrid />}
+            onClick={() => setIsOpen((prev: boolean) => !prev)}
+          />
+        </Flex>
+        <Flex align="center" direction="column" gap="4" mb="16">
+          <Avatar size={isOpen ? 'lg' : 'md'} src="" />
+          {isOpen && (
+            <Text textStyle="bold_2xl" px="10" py="1" color="white" bg="green_dark" rounded="full">
+              두레
+            </Text>
+          )}
+          <Flex direction={isOpen ? 'row' : 'column'} gap="4">
+            <SidebarIconButton icon={<BiBell />} onClick={() => {}} />
+            <SidebarIconButton icon={<BiUser />} onClick={() => {}} />
+            <SidebarIconButton icon={<MdOutlineLogout />} onClick={() => {}} />
+          </Flex>
+        </Flex>
+        {isOpen && (
+          <>
+            <Flex direction="column" p="4" bg="green_dark" roundedTop="2xl">
+              <Flex align="center" justify="space-between" gap="2">
+                <Text textStyle="bold_xl" color="white" whiteSpace="nowrap">
+                  TEAM & STUDY
+                </Text>
+                <IconButton
+                  color="black"
+                  bg="white"
+                  aria-label=""
+                  icon={<BsPlus />}
+                  onClick={() => setCreateTeamModalIsOpen(true)}
+                  size="icon_sm"
+                />
+              </Flex>
             </Flex>
-          </Flex>
-          <Flex
-            className="scroll_hide"
-            direction="column"
-            gap="4"
-            overflowY="scroll"
-            h="100%"
-            p="4"
-            bg="green_dark"
-            roundedBottom="2xl"
-          >
-            {sidebarData.map((item) => (
-              <Category key={item.id} id={item.id} name={item.name} subCategory={item.studyList} />
-            ))}
-          </Flex>
-        </>
-      )}
-    </Flex>
+            <Flex
+              className="scroll_hide"
+              direction="column"
+              gap="4"
+              overflowY="scroll"
+              h="100%"
+              p="4"
+              bg="green_dark"
+              roundedBottom="2xl"
+            >
+              {sidebarData.map((item) => (
+                <Category key={item.id} id={item.id} name={item.name} subCategory={item.studyList} />
+              ))}
+            </Flex>
+          </>
+        )}
+      </Flex>
+      <CreateTeamModal isOpen={createTeamModalIsOpen} setIsOpen={setCreateTeamModalIsOpen} />
+    </>
   );
 };
 export default SidebarContent;

--- a/src/components/Sidebar/type.ts
+++ b/src/components/Sidebar/type.ts
@@ -21,3 +21,8 @@ export interface SidebarContentProps {
   isOpen: boolean;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
+
+export interface CreateTeamModalProps {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}


### PR DESCRIPTION
### 관련 이슈
- close #186 

### 작업 요약
- 팀 생성 모달을 구현했습니다.


### 리뷰 요구 사항
- 리뷰 예상 시간 : `15분`
- 피그마에서는 제일 위에 `*표시는 필수 입력 란입니다.`로 알려주고 있는데요. 
일단 타이틀 뒤에 바로 적기에는 modal을 수정해야 할 것 같아서 각 칸의 입력이 없을 때 그 밑에 alert 문구 띄워주도록 했습니다.
이것 괜찮을까요?
- 프레스홀드에는 팀 소개글을 작성해달라고 적혀있는데, 제목에는 `팀 소개`라고 적혀있는 것이 어색해서 `팀 소개글`로 바꾸었는데 괜찮을까요?
- 원래는 썸네일 미리보기가 없었는데요. 그냥 보고 싶을 것 같기도 해서 넣었습니다. 혹시 별로라면 말씀해주세요. 바로 수정하겠습니다!
- 마지막으로 지금 IconBox 컴포넌트의 height이 다른 컴포넌트랑 안맞아서 수정해야할 것 같습니다. 이부분은 다음에 다른 브랜치를 생성해서 만들겠습니다.
- 아 하나더요. 지금 isOpen, setIsOpen 만들 props로 가지는 컴포넌트가 좀 생길 것 같은데 한개로 통일하는 것이 나을까요? 아니면 할때마다 만드는 것이 좋을까요?
<img width="240" alt="스크린샷 2024-04-11 오후 1 51 29" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/77055208/1859d5a2-272f-47c6-984d-8d63929addd6" /> <br/>
<img width="240" alt="스크린샷 2024-04-11 오후 1 47 24" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/77055208/eef3acc3-72be-4b12-98a2-572c2d0dc6ab" />
<img width="240" alt="스크린샷 2024-04-11 오후 1 47 34" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/77055208/88bfb996-1bab-4558-8b5c-6cb471f8e490" />
<img width="240" alt="스크린샷 2024-04-11 오후 1 47 51" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/77055208/da5f842d-d05f-4863-bb84-a33c92481cce" />

```tsx
'use client';

import { Box } from '@chakra-ui/react';
import { useState } from 'react';

import CreateTeamModal from '@/components/Sidebar/CreateTeamModal';

const Page = () => {
  const [open, setOpen] = useState<boolean>(true);

  return (
    <Box>
      <CreateTeamModal isOpen={open} setIsOpen={setOpen} />
    </Box>
  );
};

export default Page;
```
