### PR TITLE
Feature/#214 스터디 자료 전체보기

### DIFF
--- a/src/app/team/[teamId]/study/[studyId]/page.tsx
+++ b/src/app/team/[teamId]/study/[studyId]/page.tsx
@@ -1,4 +1,6 @@
-import { Flex, Grid } from '@chakra-ui/react';
+import { Flex, Grid, IconButton, Text, Link } from '@chakra-ui/react';
+import NextLink from 'next/link';
+import { MdOutlineArrowForwardIos } from 'react-icons/md';
 
 import CurriculumCard from '@/components/CurriculumCard';
 import StudyAssetCard from '@/components/StudyAssetCard';
@@ -26,18 +28,31 @@ const Page = () => {
       <Grid gap="4" templateColumns={{ base: '', xl: '2fr 1fr' }} w="100%">
         <Flex direction="column" rowGap={{ base: '6', '2xl': '12' }}>
           <CurriculumCard />
-          <Grid gap="2" templateColumns={{ base: 'repeat(2, 1fr)', lg: 'repeat(4, 1fr)' }}>
-            {studyAssetCardData.map((data) => (
-              <StudyAssetCard
-                key={data.title}
-                title={data.title}
-                content={data.content}
-                date={data.date}
-                bookmark={data.bookmark}
-                img={data.img}
+          <Flex align="right" direction="column" rowGap="3">
+            <Link as={NextLink} gap="3" display="flex" w="fit-content" ml="auto" href="/">
+              <IconButton
+                fontSize="16px"
+                aria-label=""
+                icon={<MdOutlineArrowForwardIos />}
+                isRound
+                size="icon_sm"
+                variant="icon_orange"
               />
-            ))}
-          </Grid>
+              <Text>전체 보기</Text>
+            </Link>
+            <Grid gap="2" templateColumns={{ base: 'repeat(2, 1fr)', lg: 'repeat(4, 1fr)' }}>
+              {studyAssetCardData.map((data) => (
+                <StudyAssetCard
+                  key={data.title}
+                  title={data.title}
+                  content={data.content}
+                  date={data.date}
+                  bookmark={data.bookmark}
+                  img={data.img}
+                />
+              ))}
+            </Grid>
+          </Flex>
         </Flex>
         <Flex direction="column" rowGap={{ base: '6', '2xl': '12' }}>
           <Feed />

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -16,6 +16,10 @@ const Button = defineStyleConfig({
       color: 'white',
       minW: '24',
     },
+    icon_orange: {
+      bg: 'orange',
+      color: 'white',
+    },
     transparent: {
       bg: 'transparent',
       color: 'white',


### PR DESCRIPTION
### 관련 이슈

- close #214

### 작업 요약

- 스터디 페이지의 스터디 자료 전체보기 링크 입니다

### 작업 상세 설명

- Link의 href를 학습자료 페이지로 바꾸면 될듯 합니다

### 리뷰 요구 사항

- button theme에서 `variant="orange"` 를 사용하려 했는데 해당 속성에서 min-width 때문에 아이콘이 원형으로 유지가 안됩니다... 일단 icon_orange 를 추가로 만들어 사용했습니다.
- charka ui의 Link를 사용했는데 기본속성으로 hover시 글자에 밑줄이 생깁니다. 크게 거슬리는 부분은 없어 따로 제거는 안했는데 제거가 필요하면 하겠습니다.

### 미리 보기

- hover 안함
<img width="1063" alt="스크린샷 2024-05-09 오전 11 51 09" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/51306225/435f3410-7d36-4d19-8843-53da3e724b1d">

- hover
<img width="1082" alt="스크린샷 2024-05-09 오전 11 51 20" src="https://github.com/BDD-CLUB/01-doo-re-front/assets/51306225/e2ccf1c2-0a1a-46eb-be02-a9115aafa5e6">
