### PR TITLE
Feature/#238 팀 생성

### DIFF
--- a/src/app/api/fetcher.ts
+++ b/src/app/api/fetcher.ts
@@ -36,16 +36,23 @@ export const fetcher = (options?: FetcherOptions) => {
       if (interceptors?.request) {
         [url, config] = await interceptors.request(props);
       }
+
+      let fetchHeaders = {
+        ...headers,
+        ...(config?.headers || {}),
+      };
+
       if (config?.body && typeof config.body === 'object') {
-        config.body = JSON.stringify(config.body);
+        if (!(config.body instanceof FormData)) {
+          config.body = JSON.stringify(config.body);
+        } else {
+          fetchHeaders = {};
+        }
       }
       const fullUrl = url.startsWith('http') ? url : `${baseUrl}${url}`;
       let response = await fetch(fullUrl, {
         ...(config as RequestInit),
-        headers: {
-          ...headers,
-          ...(config?.headers || {}),
-        },
+        headers: fetchHeaders,
       });
       if (interceptors?.response) {
         response = await interceptors.response(response);

--- a/src/app/api/team.ts
+++ b/src/app/api/team.ts
@@ -4,49 +4,39 @@ import { fetcher } from './fetcher';
 
 const teamFetcher = fetcher();
 
-const postTeamFetch = (team: FormData) =>
+const postTeam = (team: FormData) =>
   teamFetcher('/teams', {
     method: 'POST',
     body: team,
   });
 
-const putEditTeamFetch = (teamId: number, team: EditTeamDto) =>
+const putEditTeam = (teamId: number, team: EditTeamDto) =>
   teamFetcher(`/teams/${teamId}`, {
     method: 'PUT',
     body: team,
   });
 
-const patchEditTeamImageFetch = (teamId: number, file: FormData) =>
+const patchEditTeamImage = (teamId: number, file: FormData) =>
   teamFetcher(`/teams/${teamId}/image`, {
     method: 'PATCH',
-    headers: {
-      'Content-Type': 'multipart/form-data',
-    },
     body: file,
   });
 
-const deleteTeamFetch = (teamId: number) =>
+const deleteTeam = (teamId: number) =>
   teamFetcher(`/teams/${teamId}`, {
     method: 'DELETE',
   });
 
-const postInviteTeamFetch = (teamId: number, code: string) =>
+const postInviteTeam = (teamId: number, code: string) =>
   teamFetcher(`/teams/${teamId}/invite-code`, {
     method: 'POST',
     body: code,
   });
 
-const postJoinTeamFetch = (teamId: number, code: string) =>
+const postJoinTeam = (teamId: number, code: string) =>
   teamFetcher(`/teams/${teamId}/join`, {
     method: 'POST',
     body: code,
   });
 
-export {
-  postTeamFetch,
-  putEditTeamFetch,
-  patchEditTeamImageFetch,
-  deleteTeamFetch,
-  postInviteTeamFetch,
-  postJoinTeamFetch,
-};
+export { postTeam, putEditTeam, patchEditTeamImage, deleteTeam, postInviteTeam, postJoinTeam };

--- a/src/app/api/team.ts
+++ b/src/app/api/team.ts
@@ -7,7 +7,6 @@ const teamFetcher = fetcher();
 const postTeamFetch = (team: FormData) =>
   teamFetcher('/teams', {
     method: 'POST',
-    headers: { 'Content-Type': 'multipart/form-data' },
     body: team,
   });
 

--- a/src/app/api/team.ts
+++ b/src/app/api/team.ts
@@ -4,7 +4,7 @@ import { fetcher } from './fetcher';
 
 const teamFetcher = fetcher();
 
-const postTeam = (team: FormData) =>
+const postCreateTeam = (team: FormData) =>
   teamFetcher('/teams', {
     method: 'POST',
     body: team,
@@ -39,4 +39,4 @@ const postJoinTeam = (teamId: number, code: string) =>
     body: code,
   });
 
-export { postTeam, putEditTeam, patchEditTeamImage, deleteTeam, postInviteTeam, postJoinTeam };
+export { postCreateTeam, putEditTeam, patchEditTeamImage, deleteTeam, postInviteTeam, postJoinTeam };

--- a/src/components/Sidebar/CreateTeamModal/index.tsx
+++ b/src/components/Sidebar/CreateTeamModal/index.tsx
@@ -4,6 +4,7 @@ import { Flex, Text, Textarea, Image } from '@chakra-ui/react';
 import { useRef, useState } from 'react';
 import { BiEdit, BiFile } from 'react-icons/bi';
 
+import { postTeamFetch } from '@/app/api/team';
 import IconBox from '@/components/IconBox';
 import ActionModal from '@/components/Modal/ActionModal';
 
@@ -38,8 +39,19 @@ const CreateTeamModal = ({ isOpen, setIsOpen }: CreateTeamModalProps) => {
     if (name === '') setAlertName(true);
     else if (description === '') setAlertDescription(true);
     else {
-      // TODO - API 연결
-      setIsOpen(false);
+      const teamForm = new FormData();
+      const request = {
+        name,
+        description,
+      };
+      const requestBlob = new Blob([JSON.stringify(request)], { type: 'application/json' });
+
+      teamForm.append('request', requestBlob);
+      teamForm.append('file', thumbnail as Blob);
+
+      postTeamFetch(teamForm).then(() => {
+        setIsOpen(false);
+      });
     }
   };
 

--- a/src/components/Sidebar/SidebarContent/index.tsx
+++ b/src/components/Sidebar/SidebarContent/index.tsx
@@ -14,7 +14,7 @@ import Category from '../Category';
 import { SidebarContentProps } from '../type';
 
 const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
-  const [isCreateTeamModalOpen, setIsCreateTeamModalOpen] = useState<boolean>(false);
+  const [isTeamModalOpen, setIsTeamModalOpen] = useState<boolean>(false);
 
   return (
     <>
@@ -68,7 +68,7 @@ const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
                   bg="white"
                   aria-label=""
                   icon={<BsPlus />}
-                  onClick={() => setIsCreateTeamModalOpen(true)}
+                  onClick={() => setIsTeamModalOpen(true)}
                   size="icon_sm"
                 />
               </Flex>
@@ -90,7 +90,7 @@ const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
           </>
         )}
       </Flex>
-      <TeamModal isOpen={isCreateTeamModalOpen} setIsOpen={setIsCreateTeamModalOpen} />
+      <TeamModal isOpen={isTeamModalOpen} setIsOpen={setIsTeamModalOpen} />
     </>
   );
 };

--- a/src/components/Sidebar/SidebarContent/index.tsx
+++ b/src/components/Sidebar/SidebarContent/index.tsx
@@ -6,11 +6,11 @@ import { BiBell, BiUser } from 'react-icons/bi';
 import { BsPlus, BsGrid } from 'react-icons/bs';
 import { MdOutlineLogout } from 'react-icons/md';
 
+import TeamModal from '@/containers/team/TeamModal';
 import sidebarData from '@/mocks/sidebar';
 
 import SidebarIconButton from '../Button/SidebarIconButton';
 import Category from '../Category';
-import CreateTeamModal from '../CreateTeamModal';
 import { SidebarContentProps } from '../type';
 
 const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
@@ -90,7 +90,7 @@ const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
           </>
         )}
       </Flex>
-      <CreateTeamModal isOpen={isCreateTeamModalOpen} setIsOpen={setIsCreateTeamModalOpen} />
+      <TeamModal isOpen={isCreateTeamModalOpen} setIsOpen={setIsCreateTeamModalOpen} />
     </>
   );
 };

--- a/src/containers/team/TeamModal/index.tsx
+++ b/src/containers/team/TeamModal/index.tsx
@@ -4,7 +4,7 @@ import { Flex, Text, Textarea, Image } from '@chakra-ui/react';
 import { useRef, useState } from 'react';
 import { BiEdit, BiFile } from 'react-icons/bi';
 
-import { postTeam } from '@/app/api/team';
+import { postCreateTeam } from '@/app/api/team';
 import IconBox from '@/components/IconBox';
 import ActionModal from '@/components/Modal/ActionModal';
 
@@ -49,7 +49,7 @@ const TeamModal = ({ isOpen, setIsOpen }: TeamModalProps) => {
       teamForm.append('request', requestBlob);
       teamForm.append('file', thumbnail as Blob);
 
-      postTeam(teamForm).then(() => {
+      postCreateTeam(teamForm).then(() => {
         onClose();
       });
     }

--- a/src/containers/team/TeamModal/index.tsx
+++ b/src/containers/team/TeamModal/index.tsx
@@ -50,7 +50,7 @@ const TeamModal = ({ isOpen, setIsOpen }: TeamModalProps) => {
       teamForm.append('file', thumbnail as Blob);
 
       postTeamFetch(teamForm).then(() => {
-        setIsOpen(false);
+        onClose();
       });
     }
   };

--- a/src/containers/team/TeamModal/index.tsx
+++ b/src/containers/team/TeamModal/index.tsx
@@ -8,7 +8,7 @@ import { postTeamFetch } from '@/app/api/team';
 import IconBox from '@/components/IconBox';
 import ActionModal from '@/components/Modal/ActionModal';
 
-import { CreateTeamModalProps } from '../type';
+import { TeamModalProps } from './type';
 
 const AlertContent = ({ message }: { message: string }) => {
   return (
@@ -18,7 +18,7 @@ const AlertContent = ({ message }: { message: string }) => {
   );
 };
 
-const CreateTeamModal = ({ isOpen, setIsOpen }: CreateTeamModalProps) => {
+const TeamModal = ({ isOpen, setIsOpen }: TeamModalProps) => {
   const inputFileRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState<string>('');
   const [description, setDescription] = useState<string>('');
@@ -128,4 +128,4 @@ const CreateTeamModal = ({ isOpen, setIsOpen }: CreateTeamModalProps) => {
   );
 };
 
-export default CreateTeamModal;
+export default TeamModal;

--- a/src/containers/team/TeamModal/index.tsx
+++ b/src/containers/team/TeamModal/index.tsx
@@ -4,7 +4,7 @@ import { Flex, Text, Textarea, Image } from '@chakra-ui/react';
 import { useRef, useState } from 'react';
 import { BiEdit, BiFile } from 'react-icons/bi';
 
-import { postTeamFetch } from '@/app/api/team';
+import { postTeam } from '@/app/api/team';
 import IconBox from '@/components/IconBox';
 import ActionModal from '@/components/Modal/ActionModal';
 
@@ -49,7 +49,7 @@ const TeamModal = ({ isOpen, setIsOpen }: TeamModalProps) => {
       teamForm.append('request', requestBlob);
       teamForm.append('file', thumbnail as Blob);
 
-      postTeamFetch(teamForm).then(() => {
+      postTeam(teamForm).then(() => {
         onClose();
       });
     }

--- a/src/containers/team/TeamModal/type.ts
+++ b/src/containers/team/TeamModal/type.ts
@@ -1,0 +1,4 @@
+export interface TeamModalProps {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}


### PR DESCRIPTION
### 관련 이슈

- close #238 

### 작업 요약

- 팀 생성 모달에 API 연결

### 작업 상세 설명

- team.ts에 Fetch 모두 제거 했습니다
- multiformdata의 경우 header가 제대로 안들어가는 문제가 있어 수정했습니다. 연결된 api 중에서는 팀 생성만 해당하지만, 추가로 연결하는 팀 썸네일 변경에도 같은 문제가 발생할 것으로 보여 이 PR이 머지된 후에 작업해야 할 듯 합니다. ( @pipisebastian )
- 팀 수정과 생성 모달을 함께 사용하기 위해서 CreateTeamModal을 TeamModal로 변경하였습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간 : 8분