### PR TITLE
bug : get 제외 json 파싱 못하도록 수정

### DIFF
--- a/src/app/api/fetcher.ts
+++ b/src/app/api/fetcher.ts
@@ -67,10 +67,13 @@ export const fetcher = (options?: FetcherOptions) => {
         response = await interceptors.response(response);
       }
 
-      if (response.status === 201) {
-        return { ok: true, body: { message: 'Created' } };
+      const method = config?.method ?? 'GET';
+      let body = {};
+
+      if (response.ok && method === 'GET') {
+        body = await response.json();
       }
-      return { ok: true, body: await response?.json() };
+      return { ok: true, body };
     } catch (error) {
       let message = '';
       if (error instanceof Error) message = error.message;


### PR DESCRIPTION
 

### 관련 이슈

- close #274

### 작업 요약

- `get`, `put`, `post` .. 등 모든 요청이 fetch 함수 하나로 동작하는데, 
- `put`, `post` 는  response.json() 할 response가 없습니다.
-  이 때문에 사진과 같은 에러가 떴고
![image](https://github.com/BDD-CLUB/01-doo-re-front/assets/81643702/3278637e-d7c4-49cf-bea2-cc5e05f3de22)

- 원래는 put, post 가 정상적으로 되어`ok : true`로 들어가더라도, 이 에러때문에 다시 `ok : false` 로 들어가더라구요!
- 그래서 GET 메서드일 경우에만 json 파싱을 하도록 수정했습니다!



### 리뷰 요구 사항

- 1분


