### PR TITLE
Feature/#299 사이드바 외부 클릭시 닫히게

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -29,7 +29,11 @@ const Sidebar = () => {
           setIsOpen(false);
         }}
       >
-        <Box pos="absolute" w={isOpen ? { base: '215px', lg: '230px', '2xl': '240px' } : '52px'}>
+        <Box
+          pos="absolute"
+          w={isOpen ? { base: '215px', lg: '230px', '2xl': '240px' } : '52px'}
+          onClick={(e) => e.stopPropagation()}
+        >
           <SidebarContent isOpen={isOpen} setIsOpen={setIsOpen} />
         </Box>
       </Box>

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -25,6 +25,9 @@ const Sidebar = () => {
         w={!isDesktop && isOpen ? '100%' : '0'}
         h="100%"
         bg={!isDesktop && isOpen ? 'rgba(0,0,0,0.5)' : ''}
+        onClick={() => {
+          setIsOpen(false);
+        }}
       >
         <Box pos="absolute" w={isOpen ? { base: '215px', lg: '230px', '2xl': '240px' } : '52px'}>
           <SidebarContent isOpen={isOpen} setIsOpen={setIsOpen} />


### PR DESCRIPTION
### 관련 이슈

- close #299 

### 작업 요약

- 사이드바의 검은 공간 클릭시 닫히게함

### 작업 상세 설명

- 모바일 UI에서 사이드바를 펼쳤을 때 나오는 검은 공간을 누르면 닫히도록 했습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간 : 1분
- 데스크탑 UI에서는 애초에 검은 화면이 안뜨기에 펼쳐두고 사용할 수 있는걸 가정한걸로 생각하고 따로 수정은 안했습니다. 데스크탑에서도 해당 기능이 필요할지 의견이 필요합니다.
