### PR TITLE
Feature/#304 팀페이지 권한 수정

### DIFF
--- a/src/app/team/[teamId]/page.tsx
+++ b/src/app/team/[teamId]/page.tsx
@@ -145,8 +145,8 @@ const Page = ({ params }: { params: { teamId: number } }) => {
   const myTeam = useAtomValue(myTeamAtom);
   const [isMyTeam, setIsMyTeam] = useState<boolean>(false);
   useEffect(() => {
-    if (myTeam.teams !== undefined) {
-      const res = myTeam.teams.filter((teamId) => teamId === params.teamId);
+    if (myTeam !== undefined) {
+      const res = myTeam.filter((teamId) => teamId === Number(params.teamId));
       setIsMyTeam(res.length === 1);
     }
   }, [myTeam, params.teamId]);

--- a/src/atom.ts
+++ b/src/atom.ts
@@ -15,8 +15,6 @@ export const defaultUserAtom = {
 
 export const userAtom = atomWithStorage('user', defaultUserAtom as UserAtomType);
 
-export const myTeamAtom = atomWithStorage<{ teams: number[] }>('myTeam', {
-  teams: [],
-});
+export const myTeamAtom = atomWithStorage('myTeam', []);
 
 export const loginBackPathAtom = atomWithStorage('loginBackPath', '/');

--- a/src/components/Sidebar/SidebarContent/index.tsx
+++ b/src/components/Sidebar/SidebarContent/index.tsx
@@ -2,13 +2,13 @@
 
 import { Avatar, Button, Flex, IconButton, Text } from '@chakra-ui/react';
 import { useSetAtom } from 'jotai';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BiBell, BiUser } from 'react-icons/bi';
 import { BsPlus, BsGrid } from 'react-icons/bs';
 import { MdOutlineLogout } from 'react-icons/md';
 
 import { useGetSideBarInfoQuery } from '@/app/api/member';
-import { defaultUserAtom, userAtom } from '@/atom';
+import { defaultUserAtom, myTeamAtom, userAtom } from '@/atom';
 import TeamModal from '@/containers/team/TeamModal';
 import useGetUser from '@/hooks/useGetUser';
 
@@ -20,7 +20,15 @@ const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
   const [isTeamModalOpen, setIsTeamModalOpen] = useState<boolean>(false);
   const user = useGetUser();
   const setUser = useSetAtom(userAtom);
+  const setMyTeams = useSetAtom(myTeamAtom);
   const { data: sidebarInfo } = useGetSideBarInfoQuery();
+
+  useEffect(() => {
+    const myTeams = sidebarInfo
+      ? sidebarInfo.body.myTeamsAndStudies.map((team: { teamId: number }) => team.teamId)
+      : [];
+    setMyTeams(myTeams);
+  }, [setMyTeams, sidebarInfo]);
 
   return (
     <>

--- a/src/components/Sidebar/SidebarContent/index.tsx
+++ b/src/components/Sidebar/SidebarContent/index.tsx
@@ -24,7 +24,7 @@ const SidebarContent = ({ isOpen, setIsOpen }: SidebarContentProps) => {
   const { data: sidebarInfo } = useGetSideBarInfoQuery();
 
   useEffect(() => {
-    const myTeams = sidebarInfo
+    const myTeams = sidebarInfo?.body.myTeamsAndStudies
       ? sidebarInfo.body.myTeamsAndStudies.map((team: { teamId: number }) => team.teamId)
       : [];
     setMyTeams(myTeams);


### PR DESCRIPTION
### 관련 이슈
- close #304 

### 작업 요약
- 팀페이지 권한 작업 수정

### 작업 상세 설명
- 기존의 팀원한테도 UI가 안보이는 이슈는 myTeamAtom에 내용을 저장하고 있지 않아서 입니다.
- 사이드바에서 나의 팀 정보를 불러올 때, 해당 정보를 저장해주어서 해결했습니다.

### 리뷰 요구 사항
- 리뷰 예상 시간: `3분`
