### PR TITLE
Feature/#308 팀페이지 설명글 반응형 수정

### DIFF
--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -47,6 +47,7 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
         zIndex="2"
         top="100%"
         left={isTeam ? '10' : '0'}
+        alignContent="center"
         display={{ base: isHovered ? 'block' : 'none', lg: 'none' }}
         w={{ base: '72', '2xl': '96' }}
         h="100%"

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -1,10 +1,13 @@
 import { Text, Flex, Avatar, Box } from '@chakra-ui/react';
+import { useState } from 'react';
 
 import S3_URL from '@/constants/s3Url';
 
 import { TitleProps } from './types';
 
 const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
+  const [isHovered, setIsHovered] = useState(false);
+
   return (
     <Flex pos="relative" align="center" gap="3">
       {isTeam && (
@@ -16,8 +19,11 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
           src={imageUrl ? S3_URL(imageUrl) : '/images/doore_logo.png'}
         />
       )}
-      <Text textStyle="bold_3xl">{name}</Text>
-      <Box pos="relative" display={{ base: isTeam ? 'block' : 'none', lg: 'block' }} w="10" h="12" px="2">
+      <Text textStyle="bold_3xl" onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+        {name}
+      </Text>
+
+      <Box pos="relative" display={{ base: 'none', lg: 'block' }} w="10" h="12" px="2">
         <Box pos="absolute" zIndex="1" top="50%" w="5" h="5" bg="white" transform="translate(0%, -50%) rotate(45deg)" />
         <Flex
           pos="absolute"
@@ -34,6 +40,22 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
             {description}
           </Text>
         </Flex>
+      </Box>
+
+      <Box
+        pos="absolute"
+        zIndex="2"
+        top="100%"
+        left={isTeam ? '10' : '0'}
+        display={{ base: isHovered ? 'block' : 'none', lg: 'none' }}
+        w={{ base: '72', '2xl': '96' }}
+        h="100%"
+        p="2"
+        bg="white"
+        borderRadius="base"
+        shadow="md"
+      >
+        <Text>{description}</Text>
       </Box>
     </Flex>
   );

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -17,7 +17,7 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
         />
       )}
       <Text textStyle="bold_3xl">{name}</Text>
-      <Box pos="relative" display={{ base: 'none', lg: 'block' }} w="10" h="12" px="2">
+      <Box pos="relative" display={{ base: isTeam ? 'block' : 'none', lg: 'block' }} w="10" h="12" px="2">
         <Box pos="absolute" zIndex="1" top="50%" w="5" h="5" bg="white" transform="translate(0%, -50%) rotate(45deg)" />
         <Flex
           pos="absolute"


### PR DESCRIPTION
### 관련 이슈

- close #308 

### 작업 요약

- 팀페이지 tablet, mobile 화면에서 설명글을 호버 시 보이도록 수정

### 작업 상세 설명

- 말풍선 꼬리는 없습니다..

### 리뷰 요구 사항

- 리뷰 예상 시간: 1분

### 미리 보기
![image](https://github.com/user-attachments/assets/926279b3-0329-4ec1-823f-4a20f7bbcea7)

![image](https://github.com/user-attachments/assets/86bbf366-8b11-40a2-abac-cd93bd9f37db)
