### PR TITLE
Feature/#310 사이드바 현재 보고 있지 않은 팀 이름이 주황색으로 표시되는 버그 수정

### DIFF
--- a/src/components/Sidebar/Category/index.tsx
+++ b/src/components/Sidebar/Category/index.tsx
@@ -15,7 +15,7 @@ const Category = ({ id, name, subCategory }: CategoryProps) => {
         text={name}
         isSelected={currentPath === teamPath}
         isTeam
-        isTeamMatch={currentPath.includes(teamPath)}
+        isTeamMatch={currentPath.startsWith(`${teamPath}/`)}
       />
       {subCategory.map((study) => {
         const studyPath = `${teamPath}/study/${study.id}`;


### PR DESCRIPTION
### 관련 이슈

- close #310 

### 작업 요약

- 사이드바 현재 보고 있지 않은 팀 이름이 주황색으로 표시되는 버그 수정

### 작업 상세 설명

- 이 문제는 `teamId`가 1과 12처럼 숫자가 비슷한 경우에만 발생했는데, 그 원인은 `currentPath.includes(teamPath)` 때문이었습니다. `includes` 메서드는 부분 문자열만 일치해도 `true`를 반환하기 때문에, `/team/1` 경로가 `/team/12`와도 일치한다고 잘못 인식된 것입니다.
- 따라서 `includes` 대신 `startsWith`를 사용하여 경로가 정확히 일치하는지 확인하도록 변경했습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간: 1분