### PR TITLE
Feature/#321 스터디 종료 후 스터디 상태 변경 버튼이 안 보이도록 수정

### DIFF
--- a/src/app/team/[teamId]/study/[studyId]/page.tsx
+++ b/src/app/team/[teamId]/study/[studyId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Flex, Grid, IconButton, Text, Link } from '@chakra-ui/react';
+import { Flex, Grid, IconButton, Text, Link, Card } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { useEffect, useState } from 'react';
 import { MdOutlineArrowForwardIos } from 'react-icons/md';
@@ -10,7 +10,6 @@ import { getStudy } from '@/app/api/study';
 import DocumentCard from '@/components/DocumentCard';
 import Title from '@/components/Title';
 import CurriculumCard from '@/containers/study/CurriculumCard';
-// import Feed from '@/containers/study/Feed';
 import DeleteStudyModal from '@/containers/study/Modal/DeleteStudyModal';
 import StudyModal from '@/containers/study/Modal/StudyModal';
 import TerminateStudyModal from '@/containers/study/Modal/TerminateStudyModal';
@@ -47,6 +46,7 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
             <>
               <Title name={studyData.name} description={studyData.description} />
               <StudyInfoCard
+                status={studyData.status}
                 progress={studyData.studyProgressRatio}
                 startAt={new Date(studyData.startDate)}
                 endAt={new Date(studyData.endDate)}
@@ -54,18 +54,20 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
             </>
           )}
         </Flex>
-        <StudyControlPanel
-          editModalOpen={setIsEditModalOpen}
-          terminateModalOpen={setIsTerminateModalOpen}
-          deleteModalOpen={setIsDeleteModalOpen}
-        />
+        {studyData?.status !== 'ENDED' && (
+          <StudyControlPanel
+            editModalOpen={setIsEditModalOpen}
+            terminateModalOpen={setIsTerminateModalOpen}
+            deleteModalOpen={setIsDeleteModalOpen}
+          />
+        )}
         <Grid gap="4" templateColumns={{ base: '', xl: '2fr 1fr' }} w="100%">
           <Flex direction="column" rowGap={{ base: '6', '2xl': '12' }}>
             {studyData && (
               <CurriculumCard cropId={studyData.cropId} studyProgressRatio={studyData.studyProgressRatio} />
             )}
 
-            <Flex align="right" direction="column" rowGap="3">
+            <Flex align="right" direction="column" rowGap="3" w="100%" h={{ base: '25vh', lg: '30vh', '2xl': '35vh' }}>
               <Link
                 as={NextLink}
                 gap="3"
@@ -84,21 +86,27 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
                 />
                 <Text>전체 보기</Text>
               </Link>
-              <Grid gap="2" templateColumns={{ base: 'repeat(2, 1fr)', lg: 'repeat(4, 1fr)' }}>
-                {documentArray.map((data) => (
-                  <DocumentCard
-                    id={data.id}
-                    key={data.title}
-                    title={data.title}
-                    description={data.description}
-                    date={data.date}
-                    uploaderName={data.uploaderName}
-                    setReload={() => {}}
-                    files={data.files}
-                    type={data.type}
-                  />
-                ))}
-              </Grid>
+              {documentArray && documentArray.length > 0 ? (
+                <Grid gap="2" templateColumns={{ base: 'repeat(2, 1fr)', lg: 'repeat(4, 1fr)' }}>
+                  {documentArray.map((data) => (
+                    <DocumentCard
+                      id={data.id}
+                      key={data.title}
+                      title={data.title}
+                      description={data.description}
+                      date={data.date}
+                      uploaderName={data.uploaderName}
+                      setReload={() => {}}
+                      files={data.files}
+                      type={data.type}
+                    />
+                  ))}
+                </Grid>
+              ) : (
+                <Card alignItems="center" justifyContent="center" w="100%" h="100%" borderRadius={{ base: '2xl' }}>
+                  <Text textStyle="lg">학습 자료가 존재하지 않습니다.</Text>
+                </Card>
+              )}
             </Flex>
           </Flex>
           <Flex direction="column" rowGap={{ base: '6', '2xl': '12' }}>

--- a/src/containers/study/StudyInfoCard/index.tsx
+++ b/src/containers/study/StudyInfoCard/index.tsx
@@ -4,14 +4,22 @@ import StudyProgress from '@/containers/study/StudyInfoCard/StudyProgress';
 import { StudyInfoCardProps } from '@/containers/study/StudyInfoCard/types';
 import dateFormat from '@/utils/dateFormat';
 
-const StudyInfoCard = ({ progress, startAt, endAt }: StudyInfoCardProps) => {
+const StudyInfoCard = ({ progress, startAt, endAt, status }: StudyInfoCardProps) => {
   if (progress < 0 || progress > 100) throw new Error('progress는 0~100 사이여야 합니다.');
 
   return (
     <Card p="4" bg="white" borderRadius="lg">
       <Flex columnGap="4" fontWeight="bold">
-        <Text display={{ base: 'none', '2xl': 'block' }}>스터디 진행률</Text>
-        <StudyProgress progress={progress} />
+        {status === 'ENDED' ? (
+          <Text color="orange"> &quot; 종료된 스터디 입니다. &quot;</Text>
+        ) : (
+          <>
+            {' '}
+            <Text display={{ base: 'none', '2xl': 'block' }}>스터디 진행률</Text>
+            <StudyProgress progress={progress} />
+          </>
+        )}
+
         <Text display={{ base: 'none', '2xl': 'block' }} ml="auto">
           스터디 기간
         </Text>

--- a/src/containers/study/StudyInfoCard/index.tsx
+++ b/src/containers/study/StudyInfoCard/index.tsx
@@ -11,10 +11,9 @@ const StudyInfoCard = ({ progress, startAt, endAt, status }: StudyInfoCardProps)
     <Card p="4" bg="white" borderRadius="lg">
       <Flex columnGap="4" fontWeight="bold">
         {status === 'ENDED' ? (
-          <Text color="orange"> &quot; 종료된 스터디 입니다. &quot;</Text>
+          <Text color="orange"> {' 종료된 스터디 입니다. '} </Text>
         ) : (
           <>
-            {' '}
             <Text display={{ base: 'none', '2xl': 'block' }}>스터디 진행률</Text>
             <StudyProgress progress={progress} />
           </>

--- a/src/containers/study/StudyInfoCard/types.ts
+++ b/src/containers/study/StudyInfoCard/types.ts
@@ -2,6 +2,7 @@ export interface StudyInfoCardProps {
   progress: number;
   startAt: Date;
   endAt: Date;
+  status: string;
 }
 
 export interface StudyProgressProps {


### PR DESCRIPTION
### 관련 이슈

- close #321 #313 

### 작업 요약

- 스터디 종료시 화면에 보이는 레이아웃을 수정했습니다

### 작업 상세 설명

- 스터디 종료시 스터디 상태 수정 버튼 안보이도록 수정
- 스터디 종료시 상태 프로그래스 바 대신 스터디 종료 메시지 알림

### 리뷰 요구 사항

- 없습니당
 
### 미리 보기

![스크린샷 2024-09-22 오후 8 48 09](https://github.com/user-attachments/assets/0a8304ff-b032-4ea7-b7cb-93beb3f9ca97)
