### PR TITLE
Feature/#323 팀 프로필 이미지 수정 시 바로 반영 안 되는 버그 수정

### DIFF
--- a/src/containers/team/TeamModal/index.tsx
+++ b/src/containers/team/TeamModal/index.tsx
@@ -61,6 +61,14 @@ const TeamModal = ({ teamInfo, isOpen, onClose }: TeamModalProps) => {
     return isValidName && isValidDescription;
   };
 
+  const updateTeamInfo = () => {
+    if (teamInfo) {
+      refetchSideBar();
+      refetchTeamInfo(teamInfo.id);
+      resetAndCloseModal();
+    }
+  };
+
   const handleEditTeamButtonClick = () => {
     if (!isTeamInfoValid()) return;
 
@@ -76,13 +84,12 @@ const TeamModal = ({ teamInfo, isOpen, onClose }: TeamModalProps) => {
 
             editTeamImage(teamInfo.id, teamForm).then((editTeamImageResponse) => {
               if (editTeamImageResponse.ok) {
-                resetAndCloseModal();
+                updateTeamInfo();
               }
             });
+          } else {
+            updateTeamInfo();
           }
-          refetchSideBar();
-          refetchTeamInfo(teamInfo.id);
-          resetAndCloseModal();
         }
       });
     }


### PR DESCRIPTION
### 관련 이슈

- close #323 

### 작업 요약

- 팀 프로필 이미지 수정 시 한 템포씩 딜레이가 걸리는 현상을 수정했습니다.

### 작업 상세 설명

- `editTeam` 업데이트가 끝난 후 `editTeamImage` 업데이트를 하는 동안 `refetch`가 먼저 실행되어 이미지만 바로 반영이 되지 않았습니다.

### 리뷰 요구 사항

- `await`는 쓰지 않는 것 같아 일단 `refetch`하는 코드를 따로 빼놓고 이렇게 수정해놨는데, 더 좋은 방법 있으면 알려주십시오..!
