### PR TITLE
Feature/#336 팀페이지에서 사용자 별 보이는 컴포넌트 제한

### DIFF
--- a/src/app/team/[teamId]/page.tsx
+++ b/src/app/team/[teamId]/page.tsx
@@ -58,7 +58,6 @@ const Page = ({ params }: { params: { teamId: number } }) => {
       const page = Math.floor(start / CARD_PER_PAGE);
       const size = CARD_PER_PAGE;
 
-      // TODO: 학습자료 목록 조회하기.
       getDocumentList('teams', params.teamId, page, size).then((res) => {
         if (res.ok) {
           setDocumentArray(res.body.content);
@@ -170,20 +169,21 @@ const Page = ({ params }: { params: { teamId: number } }) => {
             name={teamInfo?.body.name}
             description={teamInfo?.body.description}
           />
-          {/* TODO 자신의 팀일때만 보이도록 수정 */}
           {isMyTeam && (
             <Flex align="center" gap={{ base: '2', lg: '8' }}>
               <TeamMember teamId={params.teamId} teamName={teamInfo?.body.name} />
-              <Button
-                color="white"
-                bg="orange_dark"
-                onClick={handleInviteClick}
-                rightIcon={<BsLink45Deg size="24px" />}
-                rounded="full"
-                size="sm"
-              >
-                초대
-              </Button>
+              {isTeamLeader && (
+                <Button
+                  color="white"
+                  bg="orange_dark"
+                  onClick={handleInviteClick}
+                  rightIcon={<BsLink45Deg size="24px" />}
+                  rounded="full"
+                  size="sm"
+                >
+                  초대
+                </Button>
+              )}
             </Flex>
           )}
         </Flex>

--- a/src/app/team/[teamId]/page.tsx
+++ b/src/app/team/[teamId]/page.tsx
@@ -27,6 +27,7 @@ import SuggestionCreate from '@/containers/team/SuggestionCreate';
 import TeamControlPanel from '@/containers/team/TeamControlPanel';
 import TeamMember from '@/containers/team/teamMember';
 import { useMutateWithToken } from '@/hooks/useFetchWithToken';
+import useGetUser from '@/hooks/useGetUser';
 import { DocumentList, Garden, StudyRank } from '@/types';
 
 const Page = ({ params }: { params: { teamId: number } }) => {
@@ -143,7 +144,14 @@ const Page = ({ params }: { params: { teamId: number } }) => {
   };
 
   const myTeam = useAtomValue(myTeamAtom);
+  const user = useGetUser();
+  const [isTeamLeader, setIsTeamLeader] = useState<boolean>(false);
   const [isMyTeam, setIsMyTeam] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!user || !teamInfo) return;
+    setIsTeamLeader(user.memberId === teamInfo.body.teamLeaderId);
+  }, [user, teamInfo]);
 
   useEffect(() => {
     if (myTeam !== undefined) {
@@ -179,7 +187,7 @@ const Page = ({ params }: { params: { teamId: number } }) => {
             </Flex>
           )}
         </Flex>
-        <TeamControlPanel teamInfo={teamInfo?.body} />
+        {isTeamLeader && <TeamControlPanel teamInfo={teamInfo?.body} />}
 
         <Flex pos="relative" align="center" flex="1" gap="8">
           <Box pos="relative" overflow="hidden" w="100%" h={{ base: '250px', md: '300px', xl: '320px' }}>

--- a/src/app/team/[teamId]/page.tsx
+++ b/src/app/team/[teamId]/page.tsx
@@ -38,7 +38,7 @@ const Page = ({ params }: { params: { teamId: number } }) => {
   const [documentArray, setDocumentArray] = useState<DocumentList[]>([]);
   const [documentLength, setDocumentLength] = useState<number>(0);
   const [isCreateStudyModalOpen, setIsCreateStudyModalOpen] = useState<boolean>(false);
-  const [isCreateDocumentModalOoen, setIsCreateDocumentModalOpen] = useState<boolean>(false);
+  const [isCreateDocumentModalOpen, setIsCreateDocumentModalOpen] = useState<boolean>(false);
 
   const inviteTeam = useMutateWithToken(postInviteTeam);
   const categoryData: CreateDocument = { groupId: params.teamId, groupType: 'teams' };
@@ -229,7 +229,7 @@ const Page = ({ params }: { params: { teamId: number } }) => {
         studyInfo={null}
       />
       <CreateDocumentModal
-        isOpen={isCreateDocumentModalOoen}
+        isOpen={isCreateDocumentModalOpen}
         onClose={() => setIsCreateDocumentModalOpen(false)}
         categoryData={categoryData}
         category="create"

--- a/src/constants/team.ts
+++ b/src/constants/team.ts
@@ -5,5 +5,5 @@ export const CARD_PER_PAGE = 4;
 export const TEAM_CATEGORY_INFOS: TabButtonInfoType[] = [
   { id: 1, name: '스터디', wholeView: true, page: '/' },
   { id: 2, name: '학습자료', wholeView: true, page: '/' },
-  { id: 3, name: '작물창고', wholeView: false },
+  // { id: 3, name: '작물창고', wholeView: false },
 ];


### PR DESCRIPTION
### 관련 이슈

- close #336 

### 작업 요약
- 팀페이지에서 팀장에게만 팀의 수정 & 삭제 버튼이 보이도록 수정
- 팀페이지에서 팀장에게만 초대 버튼이 보이도록 수정

### 리뷰 요구 사항
- 리뷰예상시간 : `3분`