### PR TITLE
Feature/#341 스터디 카드에서 종료된 스터디와 진행중인 스터디 구분 표시

### DIFF
--- a/src/components/StudyCard/index.tsx
+++ b/src/components/StudyCard/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardHeader, CardBody, CardFooter, Text, Image, Progress, Link } from '@chakra-ui/react';
+import { Card, CardHeader, CardBody, CardFooter, Text, Image, Progress, Link, Badge } from '@chakra-ui/react';
 
 import CROP from '@/constants/crop';
 
@@ -15,6 +15,8 @@ const StudyCard = ({
   studyProgressRatio,
   rank,
 }: StudyCardProps) => {
+  const isOngoing = new Date() >= new Date(startDate) && (new Date() <= new Date(endDate) || !endDate);
+
   return (
     <Card
       alignItems="center"
@@ -28,8 +30,9 @@ const StudyCard = ({
       rounded="2xl"
     >
       <Link href={`/team/${teamId}/study/${id}`}>
-        <CardHeader py="2">
+        <CardHeader alignItems="center" gap="2" display="flex" py="2">
           <Text textStyle="bold_md">{name}</Text>
+          <Badge colorScheme={isOngoing ? 'purple' : 'red'}>{isOngoing ? '진행 중' : '종료'}</Badge>
         </CardHeader>
         <CardBody py="0" textAlign="center" id={cropId.toString()}>
           {CROP.filter((crop) => crop.id === cropId).map((crop) => (

--- a/src/components/StudyCard/index.tsx
+++ b/src/components/StudyCard/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardHeader, CardBody, CardFooter, Text, Image, Progress, Link, Flex } from '@chakra-ui/react';
+import { Card, CardHeader, CardBody, CardFooter, Text, Image, Progress, Link, Flex, Badge } from '@chakra-ui/react';
 
 import CROP from '@/constants/crop';
 
@@ -30,6 +30,9 @@ const StudyCard = ({
       boxSizing="border-box"
       rounded="2xl"
     >
+      <Badge pos="absolute" top="3" right="3" colorScheme={isOngoing ? 'purple' : 'red'} rounded="2xl">
+        {isOngoing ? '진행 중' : '종료'}
+      </Badge>
       <Link w="100%" href={`/team/${teamId}/study/${id}`}>
         <CardHeader py="2">
           <Text textStyle="bold_md" overflow="hidden" textAlign="center" whiteSpace="nowrap" textOverflow="ellipsis">

--- a/src/components/StudyCard/index.tsx
+++ b/src/components/StudyCard/index.tsx
@@ -1,4 +1,5 @@
 import { Card, CardHeader, CardBody, CardFooter, Text, Image, Progress, Link, Flex, Badge } from '@chakra-ui/react';
+import dayjs from 'dayjs';
 
 import CROP from '@/constants/crop';
 
@@ -15,7 +16,23 @@ const StudyCard = ({
   studyProgressRatio,
   rank,
 }: StudyCardProps) => {
-  const isOngoing = new Date() >= new Date(startDate) && (new Date() <= new Date(endDate) || !endDate);
+  const currentDate = dayjs().format('YYYY-MM-DD');
+  const isOngoing =
+    currentDate >= dayjs(startDate).format('YYYY-MM-DD') &&
+    (currentDate <= dayjs(endDate).format('YYYY-MM-DD') || !endDate);
+  const isNotStarted = currentDate < dayjs(startDate).format('YYYY-MM-DD');
+
+  const getColorScheme = () => {
+    if (isNotStarted) return 'gray';
+    if (isOngoing) return 'purple';
+    return 'red';
+  };
+
+  const getBadgeText = () => {
+    if (isNotStarted) return '진행 전';
+    if (isOngoing) return '진행 중';
+    return '종료';
+  };
 
   return (
     <Card
@@ -30,8 +47,8 @@ const StudyCard = ({
       boxSizing="border-box"
       rounded="2xl"
     >
-      <Badge pos="absolute" top="3" right="3" colorScheme={isOngoing ? 'purple' : 'red'} rounded="2xl">
-        {isOngoing ? '진행 중' : '종료'}
+      <Badge pos="absolute" top="3" right="3" colorScheme={getColorScheme()} rounded="2xl">
+        {getBadgeText()}
       </Badge>
       <Link w="100%" href={`/team/${teamId}/study/${id}`}>
         <CardHeader py="2">


### PR DESCRIPTION
### 관련 이슈

- close #341 

### 작업 요약

- 디자인이 따로 없었던 것 같아서 스터디 카드에서 진행 중인 스터디와 종료된 스터디를 Badge로 표시해주었습니다.

### 작업 상세 설명
![image](https://github.com/user-attachments/assets/71a5516f-2eb9-464d-96d9-5a98f206432e)

- Chakra Badge 컴포넌트에서 기본적으로 색상 4개를 제공하는데, 진행 중인 표시를 원래 `green`으로 하려고 했으나, 저희 프로젝트에서 `green`이라는 이름으로 색상 팔레트를 덮어서 사용하고 있기 때문에 적용이 안 되었습니다. `green` 색을 쓰려면 따로 `green` 이라고 덮어 씌어둔 이름을 `green_base`와 같이 변경하든지, 새로 `green_light`와 같이 만들어야 할 것 같은데(저희가 정의해둔 green 색은 너무 진해서), 마땅히 재사용하지도 않을 것 같아서 일단 `purple`로 해두었습니다. `orange`를 쓰자니 `red`와 너무 비슷해서 구분이 잘 안 가고, 색 조합이 영 안 맞는 것 같아서.. 혹시 다른 의견 있으시면 부탁드립니다~!
- 아니면 아래 미리보기 처럼 `orange_light`랑 `orange_dark`로 하는 게 차라리 나으려나요?

### 리뷰 요구 사항

- 리뷰 예상 시간: 2분

### 미리 보기
![image](https://github.com/user-attachments/assets/4836e9f5-31af-4c5b-b87e-2a85a375471b)
`purple`, `red`

![image](https://github.com/user-attachments/assets/4b7fa16b-fbc5-4dc1-a8fd-2f59366732e3)
`orange_light`와 `orange_dark`를 적용해본 것입니다!