### PR TITLE
Feature/#348 학습자료 수정 시 모달의 제목을 학습자료 수정으로 변경

### DIFF
--- a/src/containers/study/CreateDocumentModal/index.tsx
+++ b/src/containers/study/CreateDocumentModal/index.tsx
@@ -180,7 +180,7 @@ const CreateDocumentModal = ({ isOpen, onClose, categoryData, category }: Docume
       isOpen={isOpen}
       size="xl"
       onClose={onClose}
-      title="학습자료 등록"
+      title={`학습자료 ${category === 'create' ? '생성' : '수정'}`}
       subButtonText="취소"
       onSubButtonClick={onClose}
       mainButtonText="등록"


### PR DESCRIPTION
### 관련 이슈

- close #348

### 작업 요약

- 학습자료 수정 시 뜨는 모달의 제목을 생성에서 수정으로 바꾸었습니다.


### 리뷰 요구 사항

- 리뷰 예상 시간: 5초

### 미리 보기
![image](https://github.com/user-attachments/assets/5c08da71-213e-41c3-a455-835b49648c45)
