### PR TITLE
Feature/#349 첨부된 학습자료 클릭 시 새탭으로 띄워지도록 수정

### DIFF
--- a/src/containers/study/DocumentModal/index.tsx
+++ b/src/containers/study/DocumentModal/index.tsx
@@ -67,13 +67,20 @@ const DocumentModal = ({ id, isOpen, setIsDocsModalOpen, setReload }: DocumentMo
         <Flex direction="column" gap="2">
           {document?.type === 'IMAGE' &&
             document?.files.map((data) => (
-              <Link key={data.url} href={S3_URL(data.url)} download>
+              <Link key={data.url} href={S3_URL(data.url)} download target="_blank" rel="noopener noreferrer">
                 <Image alt={data.id.toString()} id={data.id.toString()} rounded="2xl" src={S3_URL(data.url)} />
               </Link>
             ))}
           {document?.type === 'DOCUMENT' &&
             document?.files.map((data) => (
-              <Link key={data.url} href={S3_URL(data.url)} download id={data.id.toString()}>
+              <Link
+                key={data.url}
+                href={S3_URL(data.url)}
+                download
+                id={data.id.toString()}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 <IconBox
                   // leftIcon={data.type === 'pdf' ? <BiFile size={30} /> : <BsFolder2Open size={30} />}
                   leftIcon={<BiFile size={30} />}
@@ -83,7 +90,7 @@ const DocumentModal = ({ id, isOpen, setIsDocsModalOpen, setReload }: DocumentMo
             ))}
           {document?.type === 'URL' &&
             document.files.map((data) => (
-              <Link key={data.url} href={data.url}>
+              <Link key={data.url} href={data.url} target="_blank" rel="noopener noreferrer">
                 <IconBox leftIcon={<BiLink size="30" />} content={data.url} />
               </Link>
             ))}


### PR DESCRIPTION
### 관련 이슈

- close #349

### 작업 요약

- 기존에 현재 탭에서 열리던 자료를 새 탭에서 열리도록 수정했습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간: 1분

### 미리 보기

https://github.com/user-attachments/assets/52f64089-8377-40cb-bcbe-bf523c6bb0b7
