### PR TITLE
Feature/#350 파일 여러 개 등록 시 썸네일 이미지 에러 수정

### DIFF
--- a/src/components/DocumentCard/index.tsx
+++ b/src/components/DocumentCard/index.tsx
@@ -23,7 +23,7 @@ const DocumentCard = ({ id, title, description, date, setReload, files, type }: 
         return '/png/file.png';
       }
       if (files.length > 1) {
-        return 'png/folder.png';
+        return '/png/folder.png';
       }
     }
     return '';


### PR DESCRIPTION
### 관련 이슈

- close #350

### 작업 요약

- 파일 여러 개 등록 시 썸네일 이미지가 에러나는 현상을 해결했습니다.

### 작업 상세 설명

- 그냥 이미지 파일 경로에서 슬래시가 빠져있어 발생하는 오류였습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간: 1초

### 미리 보기

![스크린샷 2024-11-22 035140](https://github.com/user-attachments/assets/6c1a2d4e-e2d5-419e-bb32-4cde0624605a)
