### PR TITLE
Feature/#360 학습자료 수정 시 파일 유형 및 추가 UI 제거

### DIFF
--- a/src/containers/study/CreateDocumentModal/index.tsx
+++ b/src/containers/study/CreateDocumentModal/index.tsx
@@ -249,49 +249,45 @@ const CreateDocumentModal = ({ isOpen, onClose, categoryData, category }: Docume
           }
           value={description}
         />
-        <StyledRadioGroup
-          title="파일 유형"
-          value={category === 'create' ? doctype : (categoryData as DocumentDetail).type}
-          onChange={category === 'create' ? (v) => setDocType(v as DocumentType) : () => {}}
-        >
-          <StyledRadio value="IMAGE">이미지</StyledRadio>
-          <StyledRadio value="DOCUMENT">파일</StyledRadio>
-          <StyledRadio value="URL">URL 링크</StyledRadio>
-        </StyledRadioGroup>
-        <Flex justify="end" direction="row" gap="4" shrink="0">
-          <Input
-            ref={urlInputRef}
-            flex="1"
-            h="7"
-            shadow="md"
-            hidden={doctype !== 'URL'}
-            placeholder="URL 링크를 입력해주세요."
-          />
-          <Button
-            w="28"
-            h="7"
-            shadow="md"
-            onClick={category === 'create' ? () => handleAddDoc[doctype]() : () => {}}
-            variant="orange"
-          >
-            추가하기
-          </Button>
-        </Flex>
-        <Divider borderWidth="2px" borderColor={color.orange_dark} />
-        <input
-          hidden
-          type="file"
-          multiple
-          accept="image/jpg,image/png,image/jpeg,image/gif"
-          ref={imgInputRef}
-          onChange={handleGetDoc.IMAGE}
-        />
-        <input
-          hidden
-          type="file"
-          multiple
-          ref={fileInputRef}
-          accept="text/plain,
+        {category === 'create' && (
+          <>
+            <StyledRadioGroup
+              title="파일 유형"
+              value={category === 'create' ? doctype : (categoryData as DocumentDetail).type}
+              onChange={category === 'create' ? (v) => setDocType(v as DocumentType) : () => {}}
+            >
+              <StyledRadio value="IMAGE">이미지</StyledRadio>
+              <StyledRadio value="DOCUMENT">파일</StyledRadio>
+              <StyledRadio value="URL">URL 링크</StyledRadio>
+            </StyledRadioGroup>
+            <Flex justify="end" direction="row" gap="4" shrink="0">
+              <Input
+                ref={urlInputRef}
+                flex="1"
+                h="7"
+                shadow="md"
+                hidden={doctype !== 'URL'}
+                placeholder="URL 링크를 입력해주세요."
+              />
+              <Button w="28" h="7" shadow="md" onClick={() => handleAddDoc[doctype]()} variant="orange">
+                추가하기
+              </Button>
+            </Flex>
+            <Divider borderWidth="2px" borderColor={color.orange_dark} />
+            <input
+              hidden
+              type="file"
+              multiple
+              accept="image/jpg,image/png,image/jpeg,image/gif"
+              ref={imgInputRef}
+              onChange={handleGetDoc.IMAGE}
+            />
+            <input
+              hidden
+              type="file"
+              multiple
+              ref={fileInputRef}
+              accept="text/plain,
                   application/zip,
                   application/pdf,
                   application/vnd.ms-powerpoint,
@@ -306,20 +302,22 @@ const CreateDocumentModal = ({ isOpen, onClose, categoryData, category }: Docume
                   image/png,
                   image/gif,
                   image/webp"
-          onChange={handleGetDoc.DOCUMENT}
-        />
-        <Flex direction="column" gap="4" overflow="scroll" maxH="52" shrink="0">
-          {docList[doctype] &&
-            docList[doctype].map((doc, index) => (
-              <IconBox
-                key={doc.key}
-                leftIcon={DocumentBoxIcon[doctype]}
-                content={doc.name}
-                rightIcon={<BiTrash />}
-                handleClick={category === 'create' ? () => handleRemoveDoc(index) : () => {}}
-              />
-            ))}
-        </Flex>
+              onChange={handleGetDoc.DOCUMENT}
+            />
+            <Flex direction="column" gap="4" overflow="scroll" maxH="52" shrink="0">
+              {docList[doctype] &&
+                docList[doctype].map((doc, index) => (
+                  <IconBox
+                    key={doc.key}
+                    leftIcon={DocumentBoxIcon[doctype]}
+                    content={doc.name}
+                    rightIcon={<BiTrash />}
+                    handleClick={category === 'create' ? () => handleRemoveDoc(index) : () => {}}
+                  />
+                ))}
+            </Flex>
+          </>
+        )}
         <StyledRadioGroup
           title="공개 범위"
           defaultValue={category === 'create' ? 'ALL' : (categoryData as DocumentDetail).accessType}


### PR DESCRIPTION
### 관련 이슈

- close #360

### 작업 요약

- 학습자료 수정 시 파일 관련된 UI가 보이지 않도록 수정했습니다.

### 작업 상세 설명

- 백엔드에게 여쭤본 결과, 학습자료 수정 시에는 제목과 설명, 공개 범위만 수정이 가능하고 파일은 수정이 불가능하다고 합니다. 따라서 UI를 수정해주었습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간: 1분

### 미리 보기

![image](https://github.com/user-attachments/assets/eff0d120-8f67-4fee-a368-a9304942c136)
