### PR TITLE
Feature/#361 학습자료 생성 시 링크는 1개만 첨부할 수 있도록 수정

### DIFF
--- a/src/containers/study/CreateDocumentModal/index.tsx
+++ b/src/containers/study/CreateDocumentModal/index.tsx
@@ -264,13 +264,17 @@ const CreateDocumentModal = ({ isOpen, onClose, categoryData, category }: Docume
             flex="1"
             h="7"
             shadow="md"
+            _disabled={{ cursor: 'not-allowed', bg: 'orange_light', _hover: { bg: 'orange_light' } }}
             hidden={doctype !== 'URL'}
-            placeholder="URL 링크를 입력해주세요."
+            isDisabled={docList.URL.length > 0}
+            placeholder={docList.URL.length > 0 ? '링크는 1개만 첨부 가능합니다.' : 'URL 링크를 입력해주세요.'}
           />
           <Button
             w="28"
             h="7"
             shadow="md"
+            _disabled={{ cursor: 'not-allowed', bg: 'orange_light', _hover: { bg: 'orange_light' } }}
+            isDisabled={doctype === 'URL' && docList.URL.length > 0}
             onClick={category === 'create' ? () => handleAddDoc[doctype]() : () => {}}
             variant="orange"
           >


### PR DESCRIPTION
### 관련 이슈

- close #361

### 작업 요약

- 학습자료 생성 시 링크를 여러 개 등록할 수 있었던 기능을 하나의 링크만 첨부할 수 있도록 수정하였습니다.

### 작업 상세 설명

- `disabled`된 경우 색상은 `orange_light`가 되도록 하였습니다.
- 링크 첨부 유무에 따라 input란의 `placeholder` 문구도 변경되게 하였습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간: 1분

### 미리 보기

https://github.com/user-attachments/assets/5202695c-0cd0-4f97-8555-3fba83e7fe89

