### PR TITLE
Feature/#358 팀과스터디 UI 수정

### DIFF
--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -19,7 +19,12 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
           src={imageUrl ? S3_URL(imageUrl) : '/images/doore_logo.png'}
         />
       )}
-      <Text textStyle="bold_3xl" onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+      <Text
+        textStyle="bold_3xl"
+        cursor="default"
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
         {name}
       </Text>
 

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -41,7 +41,7 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
           borderRadius="base"
           shadow="md"
         >
-          <Text zIndex="2" w="100%" h="6">
+          <Text zIndex="2" w="100%" h="6" whiteSpace="pre-line" noOfLines={1}>
             {description}
           </Text>
         </Flex>

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -40,8 +40,24 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
           bg="white"
           borderRadius="base"
           shadow="md"
+          _hover={{
+            h: 'auto',
+          }}
+          role="group"
         >
-          <Text zIndex="2" w="100%" h="6" whiteSpace="pre-line" noOfLines={1}>
+          <Text
+            zIndex="2"
+            w="100%"
+            h="6"
+            _groupHover={{
+              h: '100%',
+              py: 3,
+              overflow: 'visible',
+              WebkitLineClamp: 'unset',
+            }}
+            whiteSpace="pre-wrap"
+            noOfLines={1}
+          >
             {description}
           </Text>
         </Flex>


### PR DESCRIPTION
### 관련 이슈

- close #358 

### 작업 요약

- 팀/스터디 UI 수정

### 작업 상세 설명

- 팀 / 스터디 설명글이 길 경우, 말풍선 바깥으로 빠져 나감
- 팀 / 스터디 명의 cursor를 default로 변경하기
- 설명글에서 개행 바꿈 적용되도록 수정

### 리뷰 요구 사항

- 리뷰 예상 시간 : 2분
