### PR TITLE
Feature/#371 학습자료 상세 조회 에러 처리

### DIFF
--- a/src/app/team/[teamId]/document/page.tsx
+++ b/src/app/team/[teamId]/document/page.tsx
@@ -34,7 +34,7 @@ const Page = ({ params }: { params: { teamId: number } }) => {
           </Button>
         )}
       </Flex>
-      <Documents groupId={params.teamId} category="teams" refetchTrigger={openCreateModal} />
+      <Documents teamId={params.teamId} groupId={params.teamId} category="teams" refetchTrigger={openCreateModal} />
       <CreateDocumentModal
         isOpen={openCreateModal}
         onClose={() => setOpenCreateModal(false)}

--- a/src/app/team/[teamId]/page.tsx
+++ b/src/app/team/[teamId]/page.tsx
@@ -239,7 +239,9 @@ const Page = ({ params }: { params: { teamId: number } }) => {
             />
           )}
           {category === '학습자료' && documentArray.length === 0 && <SuggestionCreate category="학습자료" />}
-          {category === '학습자료' && <DocumentGridView setReload={setReloadTrigger} documentArray={documentArray} />}
+          {category === '학습자료' && (
+            <DocumentGridView teamId={params.teamId} setReload={setReloadTrigger} documentArray={documentArray} />
+          )}
         </Flex>
       </Flex>
       <StudyModal

--- a/src/app/team/[teamId]/study/[studyId]/document/page.tsx
+++ b/src/app/team/[teamId]/study/[studyId]/document/page.tsx
@@ -52,7 +52,7 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
           </Button>
         )}
       </Flex>
-      <Documents groupId={params.studyId} category="studies" refetchTrigger={openCreateModal} />
+      <Documents teamId={params.teamId} groupId={params.studyId} category="studies" refetchTrigger={openCreateModal} />
       <CreateDocumentModal
         isOpen={openCreateModal}
         onClose={() => setOpenCreateModal(false)}

--- a/src/app/team/[teamId]/study/[studyId]/page.tsx
+++ b/src/app/team/[teamId]/study/[studyId]/page.tsx
@@ -144,6 +144,7 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
                 <Grid gap="2" templateColumns={{ base: 'repeat(2, 1fr)', lg: 'repeat(4, 1fr)' }}>
                   {documentArray.map((data) => (
                     <DocumentCard
+                      teamId={params.teamId}
                       id={data.id}
                       key={data.id}
                       title={data.title}

--- a/src/app/team/[teamId]/study/[studyId]/page.tsx
+++ b/src/app/team/[teamId]/study/[studyId]/page.tsx
@@ -152,6 +152,7 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
                   {documentArray.map((data) => (
                     <DocumentCard
                       teamId={params.teamId}
+                      studyId={params.studyId}
                       id={data.id}
                       key={data.id}
                       title={data.title}
@@ -161,6 +162,7 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
                       setReload={() => {}}
                       files={data.files}
                       type={data.type}
+                      category="studies"
                     />
                   ))}
                 </Grid>

--- a/src/components/DocumentCard/index.tsx
+++ b/src/components/DocumentCard/index.tsx
@@ -7,7 +7,7 @@ import S3_URL from '@/constants/s3Url';
 import DocumentModal from '@/containers/study/DocumentModal';
 import { DocumentList } from '@/types';
 
-const DocumentCard = ({ id, title, description, date, setReload, files, type }: DocumentList) => {
+const DocumentCard = ({ teamId, id, title, description, date, setReload, files, type }: DocumentList) => {
   const [docsModalOpen, setIsDocsModalOpen] = useState<boolean>(false);
 
   const firstImg = () => {
@@ -38,7 +38,13 @@ const DocumentCard = ({ id, title, description, date, setReload, files, type }: 
       onClick={() => setIsDocsModalOpen(true)}
       rounded="xl"
     >
-      <DocumentModal id={id} isOpen={docsModalOpen} setIsDocsModalOpen={setIsDocsModalOpen} setReload={setReload} />
+      <DocumentModal
+        teamId={teamId}
+        id={id}
+        isOpen={docsModalOpen}
+        setIsDocsModalOpen={setIsDocsModalOpen}
+        setReload={setReload}
+      />
 
       <Image h="60" objectFit="cover" alt="study card" rounded="sm" src={firstImg()} />
       <CardBody px="2">

--- a/src/components/DocumentCard/index.tsx
+++ b/src/components/DocumentCard/index.tsx
@@ -7,7 +7,18 @@ import S3_URL from '@/constants/s3Url';
 import DocumentModal from '@/containers/study/DocumentModal';
 import { DocumentList } from '@/types';
 
-const DocumentCard = ({ teamId, id, title, description, date, setReload, files, type }: DocumentList) => {
+const DocumentCard = ({
+  teamId,
+  studyId,
+  id,
+  title,
+  description,
+  date,
+  setReload,
+  files,
+  type,
+  category,
+}: DocumentList) => {
   const [docsModalOpen, setIsDocsModalOpen] = useState<boolean>(false);
 
   const firstImg = () => {
@@ -40,10 +51,12 @@ const DocumentCard = ({ teamId, id, title, description, date, setReload, files, 
     >
       <DocumentModal
         teamId={teamId}
+        studyId={studyId}
         id={id}
         isOpen={docsModalOpen}
         setIsDocsModalOpen={setIsDocsModalOpen}
         setReload={setReload}
+        category={category}
       />
 
       <Image h="60" objectFit="cover" alt="study card" rounded="sm" src={firstImg()} />

--- a/src/containers/document/Documents/index.tsx
+++ b/src/containers/document/Documents/index.tsx
@@ -10,7 +10,7 @@ import { DocumentList } from '@/types';
 
 import { DocumentPageProps } from './types';
 
-const Documents = ({ groupId, category, refetchTrigger = false }: DocumentPageProps) => {
+const Documents = ({ teamId, groupId, category, refetchTrigger = false }: DocumentPageProps) => {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [documentArray, setDocumentArray] = useState<DocumentList[]>([]);
   const [documentLength, setDocumentLength] = useState<number>(4);
@@ -37,7 +37,7 @@ const Documents = ({ groupId, category, refetchTrigger = false }: DocumentPagePr
           <Grid gap={{ sm: '2', md: '4', xl: '8' }} templateColumns={`repeat(${itemsPerPage / 2}, 1fr)`} w="100%">
             {currentData.map((data) => (
               <DocumentCard
-                teamId={data.teamId}
+                teamId={teamId}
                 id={data.id}
                 key={data.id}
                 title={data.title}

--- a/src/containers/document/Documents/index.tsx
+++ b/src/containers/document/Documents/index.tsx
@@ -37,6 +37,7 @@ const Documents = ({ groupId, category, refetchTrigger = false }: DocumentPagePr
           <Grid gap={{ sm: '2', md: '4', xl: '8' }} templateColumns={`repeat(${itemsPerPage / 2}, 1fr)`} w="100%">
             {currentData.map((data) => (
               <DocumentCard
+                teamId={data.teamId}
                 id={data.id}
                 key={data.id}
                 title={data.title}

--- a/src/containers/document/Documents/index.tsx
+++ b/src/containers/document/Documents/index.tsx
@@ -47,6 +47,7 @@ const Documents = ({ teamId, groupId, category, refetchTrigger = false }: Docume
                 setReload={setReload}
                 files={data.files}
                 type={data.type}
+                category={category}
               />
             ))}
           </Grid>

--- a/src/containers/document/Documents/types.ts
+++ b/src/containers/document/Documents/types.ts
@@ -1,4 +1,5 @@
 export interface DocumentPageProps {
+  readonly teamId: number;
   category: 'studies' | 'teams';
   groupId: number;
   refetchTrigger?: boolean;

--- a/src/containers/study/DocumentModal/index.tsx
+++ b/src/containers/study/DocumentModal/index.tsx
@@ -19,7 +19,7 @@ import { DocumentDetail, Member } from '@/types';
 
 import { DocumentModalProps } from './types';
 
-const DocumentModal = ({ id, isOpen, setIsDocsModalOpen, setReload }: DocumentModalProps) => {
+const DocumentModal = ({ teamId, id, isOpen, setIsDocsModalOpen, setReload }: DocumentModalProps) => {
   const [createDocsModalOpen, setIsCreateDocsModalOpen] = useState<boolean>(false);
 
   const {
@@ -44,7 +44,7 @@ const DocumentModal = ({ id, isOpen, setIsDocsModalOpen, setReload }: DocumentMo
 
   const user = useGetUser();
   const [isMember, setIsMember] = useState<boolean>(false);
-  const { result: teamMembers } = useGetFetchWithToken(getTeamMembers, [document?.teamId], user);
+  const { result: teamMembers } = useGetFetchWithToken(getTeamMembers, [teamId], user);
 
   useEffect(() => {
     if (user?.isLogin) {

--- a/src/containers/study/DocumentModal/index.tsx
+++ b/src/containers/study/DocumentModal/index.tsx
@@ -2,17 +2,20 @@
 
 import { Box, Flex, Text, Image } from '@chakra-ui/react';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BiFile, BiLink } from 'react-icons/bi';
 
 import { deleteDocument, getDocument } from '@/app/api/document';
+import { getTeamMembers } from '@/app/api/team';
 import IconBox from '@/components/IconBox';
 import ActionModal from '@/components/Modal/ActionModal';
+import AlertModal from '@/components/Modal/AlertModal';
 import S3_URL from '@/constants/s3Url';
 import CreateDocumentModal from '@/containers/study/CreateDocumentModal';
 import { useGetFetchWithToken, useMutateWithToken } from '@/hooks/useFetchWithToken';
+import useGetUser from '@/hooks/useGetUser';
 import colors from '@/theme/foundations/colors';
-import { DocumentDetail } from '@/types';
+import { DocumentDetail, Member } from '@/types';
 
 import { DocumentModalProps } from './types';
 
@@ -38,6 +41,24 @@ const DocumentModal = ({ id, isOpen, setIsDocsModalOpen, setReload }: DocumentMo
     setIsCreateDocsModalOpen(false);
     setReload((prev: boolean) => !prev);
   };
+
+  const user = useGetUser();
+  const [isMember, setIsMember] = useState<boolean>(false);
+  const { result: teamMembers } = useGetFetchWithToken(getTeamMembers, [document?.teamId], user);
+
+  useEffect(() => {
+    if (user?.isLogin) {
+      setIsMember(teamMembers?.some((member: Member) => member.id === user.memberId));
+    }
+  }, [teamMembers, user]);
+
+  if (!isMember) {
+    return (
+      <AlertModal isOpen={isOpen} onClose={() => setIsDocsModalOpen(false)} title="접근 권한이 없습니다." size="sm">
+        <Text>{user?.isLogin ? '팀원만 접근 가능합니다.' : '로그인 후 접근 가능합니다.'}</Text>
+      </AlertModal>
+    );
+  }
 
   return (
     <ActionModal

--- a/src/containers/study/DocumentModal/index.tsx
+++ b/src/containers/study/DocumentModal/index.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { BiFile, BiLink } from 'react-icons/bi';
 
 import { deleteDocument, getDocument } from '@/app/api/document';
+import { getStudyMembers } from '@/app/api/study';
 import { getTeamMembers } from '@/app/api/team';
 import IconBox from '@/components/IconBox';
 import ActionModal from '@/components/Modal/ActionModal';
@@ -19,7 +20,15 @@ import { DocumentDetail, Member } from '@/types';
 
 import { DocumentModalProps } from './types';
 
-const DocumentModal = ({ teamId, id, isOpen, setIsDocsModalOpen, setReload }: DocumentModalProps) => {
+const DocumentModal = ({
+  teamId,
+  studyId,
+  id,
+  isOpen,
+  category,
+  setIsDocsModalOpen,
+  setReload,
+}: DocumentModalProps) => {
   const [createDocsModalOpen, setIsCreateDocsModalOpen] = useState<boolean>(false);
 
   const {
@@ -43,19 +52,30 @@ const DocumentModal = ({ teamId, id, isOpen, setIsDocsModalOpen, setReload }: Do
   };
 
   const user = useGetUser();
-  const [isMember, setIsMember] = useState<boolean>(false);
+  const [isTeamMember, setIsMember] = useState<boolean>(false);
+  const [isStudyMember, setIsStudyMember] = useState<boolean>(false);
   const { result: teamMembers } = useGetFetchWithToken(getTeamMembers, [teamId], user);
+  const { result: studyMembers } = useGetFetchWithToken(getStudyMembers, [studyId], user);
 
   useEffect(() => {
     if (user?.isLogin) {
       setIsMember(teamMembers?.some((member: Member) => member.id === user.memberId));
+      setIsStudyMember(studyMembers?.some((member: { memberId: number }) => member.memberId === user.memberId));
     }
-  }, [teamMembers, user]);
+  }, [teamMembers, studyMembers, user]);
 
-  if (!isMember) {
+  if (!isTeamMember && category === 'teams') {
     return (
       <AlertModal isOpen={isOpen} onClose={() => setIsDocsModalOpen(false)} title="접근 권한이 없습니다." size="sm">
         <Text>{user?.isLogin ? '팀원만 접근 가능합니다.' : '로그인 후 접근 가능합니다.'}</Text>
+      </AlertModal>
+    );
+  }
+
+  if (!isStudyMember && category === 'studies') {
+    return (
+      <AlertModal isOpen={isOpen} onClose={() => setIsDocsModalOpen(false)} title="접근 권한이 없습니다." size="sm">
+        <Text>{user?.isLogin ? '스터디원만 접근 가능합니다.' : '로그인 후 접근 가능합니다.'}</Text>
       </AlertModal>
     );
   }

--- a/src/containers/study/DocumentModal/types.ts
+++ b/src/containers/study/DocumentModal/types.ts
@@ -7,8 +7,10 @@ export interface DocumentData {
 
 export interface DocumentModalProps {
   readonly teamId: number;
+  readonly studyId?: number;
   id: number;
   isOpen: boolean;
+  category: 'studies' | 'teams';
   setIsDocsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setReload: React.Dispatch<React.SetStateAction<boolean>>;
   // setIsCreateDocsModalOpen: () => void;

--- a/src/containers/study/DocumentModal/types.ts
+++ b/src/containers/study/DocumentModal/types.ts
@@ -6,6 +6,7 @@ export interface DocumentData {
 }
 
 export interface DocumentModalProps {
+  readonly teamId: number;
   id: number;
   isOpen: boolean;
   setIsDocsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/containers/team/DocumentGridView/index.tsx
+++ b/src/containers/team/DocumentGridView/index.tsx
@@ -20,6 +20,7 @@ const DocumentGridView = ({ teamId, documentArray, setReload = () => {} }: Docum
             setReload={setReload}
             type={document.type}
             files={document.files}
+            category="teams"
             // bookmark={document.bookmark}
             // img={document.img}
           />

--- a/src/containers/team/DocumentGridView/index.tsx
+++ b/src/containers/team/DocumentGridView/index.tsx
@@ -10,6 +10,7 @@ const DocumentGridView = ({ documentArray, setReload = () => {} }: DocumentGridV
       {documentArray?.map((document) => {
         return (
           <DocumentCard
+            teamId={document.teamId}
             key={document.id}
             id={document.id}
             title={document.title}

--- a/src/containers/team/DocumentGridView/index.tsx
+++ b/src/containers/team/DocumentGridView/index.tsx
@@ -4,13 +4,13 @@ import DocumentCard from '@/components/DocumentCard';
 
 import { DocumentGridViewProps } from './types';
 
-const DocumentGridView = ({ documentArray, setReload = () => {} }: DocumentGridViewProps) => {
+const DocumentGridView = ({ teamId, documentArray, setReload = () => {} }: DocumentGridViewProps) => {
   return (
     <Grid gap="4" templateColumns={{ base: 'repeat(2, 1fr)', lg: 'repeat(4, 1fr)' }}>
       {documentArray?.map((document) => {
         return (
           <DocumentCard
-            teamId={document.teamId}
+            teamId={teamId}
             key={document.id}
             id={document.id}
             title={document.title}

--- a/src/containers/team/DocumentGridView/types.ts
+++ b/src/containers/team/DocumentGridView/types.ts
@@ -1,6 +1,7 @@
 import { DocumentList } from '@/types';
 
 export interface DocumentGridViewProps {
+  readonly teamId: number;
   documentArray: DocumentList[];
   setReload?: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/src/mocks/documentCard.ts
+++ b/src/mocks/documentCard.ts
@@ -17,6 +17,7 @@ const documentCardData: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -34,6 +35,7 @@ const documentCardData: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -51,6 +53,7 @@ const documentCardData: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
 
   {
@@ -69,6 +72,7 @@ const documentCardData: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -86,6 +90,7 @@ const documentCardData: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
 
   {
@@ -104,6 +109,7 @@ const documentCardData: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -121,6 +127,7 @@ const documentCardData: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -138,6 +145,7 @@ const documentCardData: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
 ];
 

--- a/src/mocks/documentCard.ts
+++ b/src/mocks/documentCard.ts
@@ -2,6 +2,7 @@ import { DocumentList } from '@/types';
 
 const documentCardData: DocumentList[] = [
   {
+    teamId: 1,
     id: 1,
     title: '자료이름1',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -18,6 +19,7 @@ const documentCardData: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 2,
     title: '자료이름2',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -34,6 +36,7 @@ const documentCardData: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 3,
     title: '자료이름3',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -51,6 +54,7 @@ const documentCardData: DocumentList[] = [
   },
 
   {
+    teamId: 1,
     id: 4,
     title: '자료이름4',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -67,6 +71,7 @@ const documentCardData: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 5,
     title: '자료이름5',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -84,6 +89,7 @@ const documentCardData: DocumentList[] = [
   },
 
   {
+    teamId: 1,
     id: 6,
     title: '자료이름6',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -100,6 +106,7 @@ const documentCardData: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 7,
     title: '자료이름7',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -116,6 +123,7 @@ const documentCardData: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 8,
     title: '자료이름8',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',

--- a/src/mocks/documentCardAll.ts
+++ b/src/mocks/documentCardAll.ts
@@ -2,6 +2,7 @@ import { DocumentList } from '@/types';
 
 const documentCardDataAll: DocumentList[] = [
   {
+    teamId: 1,
     id: 1,
     title: '자료이름1',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -17,6 +18,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 2,
     title: '자료이름2',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -32,6 +34,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 3,
     title: '자료이름3',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -47,6 +50,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 4,
     title: '자료이름4',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -62,6 +66,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 5,
     title: '자료이름5',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -77,6 +82,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 6,
     title: '자료이름6',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -92,6 +98,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 7,
     title: '자료이름7',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -107,6 +114,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 8,
     title: '자료이름8',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -122,6 +130,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 9,
     title: '자료이름9',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -137,6 +146,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 10,
     title: '자료이름10',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -152,6 +162,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 11,
     title: '자료이름11',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',
@@ -167,6 +178,7 @@ const documentCardDataAll: DocumentList[] = [
     type: 'IMAGE',
   },
   {
+    teamId: 1,
     id: 12,
     title: '자료이름12',
     description: '이번 포스팅은 [스터디 목적]에 관한것입니다. 먼저 [목차]는 이렇습니다.',

--- a/src/mocks/documentCardAll.ts
+++ b/src/mocks/documentCardAll.ts
@@ -16,6 +16,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -32,6 +33,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -48,6 +50,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -64,6 +67,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -80,6 +84,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -96,6 +101,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -112,6 +118,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -128,6 +135,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -144,6 +152,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -160,6 +169,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -176,6 +186,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
   {
     teamId: 1,
@@ -192,6 +203,7 @@ const documentCardDataAll: DocumentList[] = [
       },
     ],
     type: 'IMAGE',
+    category: 'studies',
   },
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,12 +112,14 @@ export interface Document {
 
 export interface DocumentList {
   readonly teamId: number;
+  readonly studyId?: number;
   id: number;
   title: string;
   description: string;
   date: string;
   uploaderName: string;
   type: 'IMAGE' | 'DOCUMENT' | 'URL';
+  category: 'studies' | 'teams';
   // docsModalOpen: boolean;
   setReload: React.Dispatch<React.SetStateAction<boolean>>;
   files: DocumentFile[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,7 @@ export interface Document {
 }
 
 export interface DocumentList {
+  readonly teamId: number;
   id: number;
   title: string;
   description: string;


### PR DESCRIPTION
### 관련 이슈

- close #371 

### 작업 요약

- 비회원 및 팀원이 아닌 회원이 학습자료 상세 조회 접근 시 모달창으로 접근 불가 알림을 표시하도록 하였습니다.

### 작업 상세 설명

- 서버를 이전하게 되면서 제대로 작동하는지 아직 확인을 못 해봤습니다.
- 로컬에서 임의로 확인해 본 터라, 추후에 확인해 본 후 다시 수정하겠습니다!
=> 확인해본 결과, Application error는 뜨지 않았습니다. 그래도 다들 확인 부탁드립니다!

### 리뷰 요구 사항

- 처음에는 에러 처리를 카드 내에서 표시하려 했으나, 디자인적으로 애매할 것 같아 `AlertModal`을 활용해 표시했습니다. 하지만 이제 생각해보니, 스터디 카드의 진행 상태처럼 작은 Badge 형태로 '로그인 필요', '팀원만 가능' 등의 메시지를 표시하는 것도 괜찮아 보이네요.. 하지만 클릭했을 때 아무 반응이 없으면 또 이상할 것 같기도 하고.. 너무 어렵네요😵‍💫 지금 구현한 모달 알림창 형식은 다들 괜찮으신지 의견 부탁드립니다!

### 미리 보기
![스크린샷 2025-01-12 154523](https://github.com/user-attachments/assets/3def634e-dc17-4aa1-94ba-83a0bdaf9ff1)
![스크린샷 2025-01-12 161433](https://github.com/user-attachments/assets/f24751ab-a2b2-463e-9c4d-29aeabb70df7)
