### PR TITLE
Feature/#378 팀 이미지 삭제

### DIFF
--- a/src/app/api/team.ts
+++ b/src/app/api/team.ts
@@ -51,6 +51,14 @@ const patchEditTeamImage = (token: string, teamId: number, file: FormData) =>
     },
   });
 
+const deleteTeamImage = (token: string, teamId: number) =>
+  teamFetcher(`/teams/${teamId}/image`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
 const deleteTeam = (token: string, teamId: number) =>
   teamFetcher(`/teams/${teamId}`, {
     method: 'DELETE',
@@ -109,6 +117,7 @@ export {
   useGetTeamInfoQuery,
   putEditTeam,
   patchEditTeamImage,
+  deleteTeamImage,
   deleteTeam,
   postInviteTeam,
   postJoinTeam,

--- a/src/containers/team/TeamModal/index.tsx
+++ b/src/containers/team/TeamModal/index.tsx
@@ -4,7 +4,7 @@ import { Flex, Text, Textarea, Image, IconButton, Box } from '@chakra-ui/react';
 import { useEffect, useRef, useState } from 'react';
 import { BiEdit, BiFile, BiTrash } from 'react-icons/bi';
 
-import { patchEditTeamImage, postCreateTeam, putEditTeam } from '@/app/api/team';
+import { deleteTeamImage, patchEditTeamImage, postCreateTeam, putEditTeam } from '@/app/api/team';
 import IconBox from '@/components/IconBox';
 import ActionModal from '@/components/Modal/ActionModal';
 import S3_URL from '@/constants/s3Url';
@@ -30,10 +30,12 @@ const TeamModal = ({ teamInfo, isOpen, onClose }: TeamModalProps) => {
   const [thumbnail, setThumbnail] = useState<File | null>();
   const [alertName, setAlertName] = useState<boolean>(false);
   const [alertDescription, setAlertDescription] = useState<boolean>(false);
+  const [isImageDeleted, setIsImageDeleted] = useState<boolean>(false);
 
   const createTeam = useMutateWithToken(postCreateTeam);
   const editTeam = useMutateWithToken(putEditTeam);
   const editTeamImage = useMutateWithToken(patchEditTeamImage);
+  const removeTeamImage = useMutateWithToken(deleteTeamImage);
 
   const refetchSideBar = useRefetchSideBar();
   const refetchTeamInfo = useRefetchTeamInfo();
@@ -69,6 +71,12 @@ const TeamModal = ({ teamInfo, isOpen, onClose }: TeamModalProps) => {
     }
   };
 
+  const handleDeleteImage = () => {
+    setThumbnail(null);
+    setThumbnailPath('');
+    setIsImageDeleted(true);
+  };
+
   const handleEditTeamButtonClick = () => {
     if (!isTeamInfoValid()) return;
 
@@ -85,6 +93,16 @@ const TeamModal = ({ teamInfo, isOpen, onClose }: TeamModalProps) => {
             editTeamImage(teamInfo.id, teamForm).then((editTeamImageResponse) => {
               if (editTeamImageResponse.ok) {
                 updateTeamInfo();
+              } else {
+                alert('팀 이미지 수정에 실패했습니다.');
+              }
+            });
+          } else if (isImageDeleted) {
+            removeTeamImage(teamInfo.id).then((deleteImageResponse) => {
+              if (deleteImageResponse.ok) {
+                updateTeamInfo();
+              } else {
+                alert('팀 이미지 삭제에 실패했습니다.');
               }
             });
           } else {
@@ -205,10 +223,7 @@ const TeamModal = ({ teamInfo, isOpen, onClose }: TeamModalProps) => {
               borderRadius="2xl"
               aria-label=""
               icon={<BiTrash />}
-              onClick={() => {
-                setThumbnail(null);
-                setThumbnailPath('');
-              }}
+              onClick={handleDeleteImage}
               size="icon_md"
               variant="orange_light"
             />

--- a/src/containers/team/TeamModal/index.tsx
+++ b/src/containers/team/TeamModal/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Flex, Text, Textarea, Image } from '@chakra-ui/react';
+import { Flex, Text, Textarea, Image, IconButton, Box } from '@chakra-ui/react';
 import { useEffect, useRef, useState } from 'react';
-import { BiEdit, BiFile } from 'react-icons/bi';
+import { BiEdit, BiFile, BiTrash } from 'react-icons/bi';
 
 import { patchEditTeamImage, postCreateTeam, putEditTeam } from '@/app/api/team';
 import IconBox from '@/components/IconBox';
@@ -189,12 +189,30 @@ const TeamModal = ({ teamInfo, isOpen, onClose }: TeamModalProps) => {
               }
             }}
           />
-          <IconBox
-            leftIcon={<BiFile />}
-            rightIcon={<BiEdit />}
-            content={thumbnail ? thumbnail.name : '파일을 추가해주세요.'}
-            handleClick={() => inputFileRef.current?.click()}
-          />
+          <Flex align="center" gap={2} w="100%">
+            <Box w="368px">
+              <IconBox
+                leftIcon={<BiFile />}
+                rightIcon={<BiEdit />}
+                content={thumbnail ? thumbnail.name : '파일을 추가해주세요.'}
+                handleClick={() => inputFileRef.current?.click()}
+              />
+            </Box>
+            <IconButton
+              flexShrink="0"
+              minW="40px"
+              h="40px"
+              borderRadius="2xl"
+              aria-label=""
+              icon={<BiTrash />}
+              onClick={() => {
+                setThumbnail(null);
+                setThumbnailPath('');
+              }}
+              size="icon_md"
+              variant="orange_light"
+            />
+          </Flex>
           {thumbnailPath ? (
             <Image w="40" alt="thumbnail" src={S3_URL(thumbnailPath)} />
           ) : (


### PR DESCRIPTION
### 관련 이슈

- close #378 

### 작업 요약

- 팀 수정 시 이미지 삭제도 가능하도록 아이콘을 추가하였습니다.

### 작업 상세 설명

- 삭제 아이콘 버튼은 팀 이미지 수정 아이콘 오른쪽에 배치하였습니다.
- api 동작은 아직 확인을 못 해봤습니다. 추후에 확인해 본 후 다시 수정하겠습니다!

### 리뷰 요구 사항

- `IconBox` 컴포넌트에서 아이콘 크기를 `40px`로 직접 지정하여서, 수정 모달의 팀 썸네일 영역에서도 `<Box w="368px">`로 고정된 너비를 사용했는데, 직접 px을 주는 방식 외에 더 유연한 방법이 있는지 잘 모르겠습니다.. 100%를 잘 활용하고 싶었는데 마음처럼 잘 안되더라고요😥

### 미리 보기
![image](https://github.com/user-attachments/assets/6f6a1d47-4e99-4795-9db4-c1db03e80ab1)
