### PR TITLE
Feature/#388 스터디페이지에서 스터디원이 아닌 팀원에게 학습자료 생성 버튼이 안 보이도록 수정

### DIFF
--- a/src/app/team/[teamId]/study/[studyId]/page.tsx
+++ b/src/app/team/[teamId]/study/[studyId]/page.tsx
@@ -131,14 +131,16 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
                   />
                   <Text>전체 보기</Text>
                 </Link>
-                <IconButton
-                  shadow="base"
-                  aria-label=""
-                  icon={<BsPlus />}
-                  onClick={() => setIsCreateDocumentModalOpen(true)}
-                  size="icon_md"
-                  variant="icon_orange_dark"
-                />
+                {participantData && (
+                  <IconButton
+                    shadow="base"
+                    aria-label=""
+                    icon={<BsPlus />}
+                    onClick={() => setIsCreateDocumentModalOpen(true)}
+                    size="icon_md"
+                    variant="icon_orange_dark"
+                  />
+                )}
               </Flex>
               {documentArray && documentArray.length > 0 ? (
                 <Grid gap="2" templateColumns={{ base: 'repeat(2, 1fr)', lg: 'repeat(4, 1fr)' }}>


### PR DESCRIPTION
### 관련 이슈

- #388 

### 작업 요약

- 스터디페이지에서 스터디원이 아닌 팀원에게 학습자료 생성 버튼이 안 보이도록 수정했습니다.

### 리뷰 요구 사항

- 기존에는 자신이 속한 스터디인지 확인하고 그거에 따른 권한을 부여하려고 했습니다.
- 근데 이미 스터디원이 아닌 사람에게 스터디원 목록이 안 보이는 기능이 있길래... 이를 이용했습니다...ㅎㅎ
- 리뷰 예상 시간 : `1분`

### 미리 보기

![image](https://github.com/user-attachments/assets/3b362090-a1a4-402f-832d-87ea89c5fd06)
