### PR TITLE
Feature/#390 스터디페이지 팀장에게 스터디장 삭제 표시

### DIFF
--- a/src/app/team/[teamId]/study/[studyId]/page.tsx
+++ b/src/app/team/[teamId]/study/[studyId]/page.tsx
@@ -9,6 +9,7 @@ import { MdOutlineArrowForwardIos } from 'react-icons/md';
 
 import { getDocumentList } from '@/app/api/document';
 import { getStudy, getStudyMembers } from '@/app/api/study';
+import { useGetTeamInfoQuery } from '@/app/api/team';
 import DocumentCard from '@/components/DocumentCard';
 import Title from '@/components/Title';
 import CreateDocumentModal from '@/containers/study/CreateDocumentModal';
@@ -27,6 +28,7 @@ import useGetUser from '@/hooks/useGetUser';
 import { DocumentList, ParticipantType, Study, StudyMember } from '@/types';
 
 const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
+  const { data: teamInfo } = useGetTeamInfoQuery(params.teamId);
   const [studyData, setStudyData] = useState<Study>();
   const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
@@ -38,6 +40,8 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
   const router = useRouter();
   const user = useGetUser();
   const myTeam = useGetMyTeam();
+  const [isTeamLeader, setIsTeamLeader] = useState<boolean>(false);
+  const [isStudyLeader, setIsStudyLeader] = useState<boolean>(false);
   if (user && !user.isLogin) router.replace(`/team/${params.teamId}`);
   if (myTeam && !myTeam.some((id) => id === +params.teamId)) router.replace(`/team/${params.teamId}`);
 
@@ -52,6 +56,16 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
         profileImg: data.imageUrl,
       }) as ParticipantType,
   );
+
+  useEffect(() => {
+    if (!user || !teamInfo) return;
+    setIsTeamLeader(user.memberId === teamInfo.body.teamLeaderId);
+  }, [user, teamInfo, result]);
+
+  useEffect(() => {
+    if (!user || !studyData) return;
+    setIsStudyLeader(user.memberId === studyData.studyLeaderId);
+  }, [user, studyData, result]);
 
   useEffect(() => {
     getStudy(params.studyId).then((data) => {
@@ -166,11 +180,12 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
           <Flex direction="column" rowGap={{ base: '6', '2xl': '12' }}>
             {/* <Feed /> */}
             <Flex align="right" direction="column" rowGap="3">
-              {studyData && user && user.memberId === studyData.studyLeaderId && (
+              {studyData && user && (isTeamLeader || isStudyLeader) && (
                 <StudyParticipantMenu
                   studyId={params.studyId}
                   teamId={studyData?.teamReference.id}
                   leaderId={studyData?.studyLeaderId}
+                  isTeamLeader={isTeamLeader}
                   studyMembers={result || []}
                   refetchMembers={handleRefetchMembers}
                 />

--- a/src/components/ParticipantMenu/ParticipantItem/index.tsx
+++ b/src/components/ParticipantMenu/ParticipantItem/index.tsx
@@ -4,7 +4,16 @@ import { RiAddLine, RiCloseFill, RiVipCrownLine } from 'react-icons/ri';
 import { ParticipantItemProps } from '@/components/ParticipantMenu/types';
 import colors from '@/theme/foundations/colors';
 
-const ParticipantItem = ({ member, type, isLeader, onAdd, onMandateLeader, onRemove }: ParticipantItemProps) => {
+const ParticipantItem = ({
+  member,
+  type,
+  isLeader,
+  isTeamLeader,
+  category,
+  onAdd,
+  onMandateLeader,
+  onRemove,
+}: ParticipantItemProps) => {
   const handleDeleteMember = () => {
     onRemove(member);
   };
@@ -43,6 +52,26 @@ const ParticipantItem = ({ member, type, isLeader, onAdd, onMandateLeader, onRem
           {member.name}
         </Text>
       </Flex>
+      {isTeamLeader && !isLeader && type === 'LEADER' && (
+        <Flex
+          gap="2"
+          ml="auto"
+          _groupHover={{
+            visibility: 'visible',
+          }}
+          visibility="hidden"
+        >
+          <IconButton
+            color="orange_dark"
+            _hover={{ bgColor: 'transparent' }}
+            aria-label=""
+            bgColor="transparent"
+            icon={<RiCloseFill />}
+            onClick={handleDeleteMember}
+            size="icon_sm"
+          />
+        </Flex>
+      )}
       {isLeader && type === 'INCLUDE' && (
         <Flex
           gap="2"
@@ -61,15 +90,17 @@ const ParticipantItem = ({ member, type, isLeader, onAdd, onMandateLeader, onRem
             onClick={handleDeleteMember}
             size="icon_sm"
           />
-          <IconButton
-            color="orange_dark"
-            _hover={{ bgColor: 'transparent' }}
-            aria-label=""
-            bgColor="transparent"
-            icon={<RiVipCrownLine />}
-            onClick={handleMandateLeader}
-            size="icon_sm"
-          />
+          {(category !== 'studies' || !isTeamLeader || isLeader) && (
+            <IconButton
+              color="orange_dark"
+              _hover={{ bgColor: 'transparent' }}
+              aria-label=""
+              bgColor="transparent"
+              icon={<RiVipCrownLine />}
+              onClick={handleMandateLeader}
+              size="icon_sm"
+            />
+          )}
         </Flex>
       )}
       {isLeader && type === 'EXCLUDE' && (

--- a/src/components/ParticipantMenu/index.tsx
+++ b/src/components/ParticipantMenu/index.tsx
@@ -82,6 +82,8 @@ const ParticipantMenu = ({
                 key={searchedLeader.id}
                 member={searchedLeader}
                 type="LEADER"
+                isLeader={user?.memberId === searchedLeader?.id}
+                isTeamLeader={isTeamLeader}
                 category={category}
                 onRemove={onRemove}
                 onAdd={onAdd}
@@ -108,6 +110,7 @@ const ParticipantMenu = ({
                 member={member}
                 type="EXCLUDE"
                 isLeader={user?.memberId === searchedLeader?.id}
+                isTeamLeader={isTeamLeader}
                 category={category}
                 onRemove={onRemove}
                 onAdd={onAdd}

--- a/src/components/ParticipantMenu/index.tsx
+++ b/src/components/ParticipantMenu/index.tsx
@@ -17,6 +17,8 @@ const ParticipantMenu = ({
   excludeMembers = [],
   children,
   isOpen,
+  isTeamLeader,
+  category,
   setIsOpen,
   onRemove = defaultFunction,
   onAdd = defaultFunction,
@@ -80,6 +82,7 @@ const ParticipantMenu = ({
                 key={searchedLeader.id}
                 member={searchedLeader}
                 type="LEADER"
+                category={category}
                 onRemove={onRemove}
                 onAdd={onAdd}
                 onMandateLeader={onMandateLeader}
@@ -91,6 +94,8 @@ const ParticipantMenu = ({
                 member={member}
                 type="INCLUDE"
                 isLeader={user?.memberId === searchedLeader?.id}
+                isTeamLeader={isTeamLeader}
+                category={category}
                 onRemove={onRemove}
                 onAdd={onAdd}
                 onMandateLeader={onMandateLeader}
@@ -103,6 +108,7 @@ const ParticipantMenu = ({
                 member={member}
                 type="EXCLUDE"
                 isLeader={user?.memberId === searchedLeader?.id}
+                category={category}
                 onRemove={onRemove}
                 onAdd={onAdd}
                 onMandateLeader={onMandateLeader}

--- a/src/components/ParticipantMenu/index.tsx
+++ b/src/components/ParticipantMenu/index.tsx
@@ -32,6 +32,7 @@ const ParticipantMenu = ({
   const searchedLeader = leader?.name.includes(search) ? leader : null;
   const searchedIncludeMember = includeMembers.filter((member) => member.name.includes(search));
   const searchedExcludeMember = excludeMembers.filter((member) => member.name.includes(search));
+  const isLeader = user?.memberId === leader?.id;
 
   useEffect(() => {
     const handleOutsideClose = (e: MouseEvent) => {
@@ -82,7 +83,7 @@ const ParticipantMenu = ({
                 key={searchedLeader.id}
                 member={searchedLeader}
                 type="LEADER"
-                isLeader={user?.memberId === searchedLeader?.id}
+                isLeader={isLeader}
                 isTeamLeader={isTeamLeader}
                 category={category}
                 onRemove={onRemove}
@@ -95,7 +96,7 @@ const ParticipantMenu = ({
                 key={member.id}
                 member={member}
                 type="INCLUDE"
-                isLeader={user?.memberId === searchedLeader?.id}
+                isLeader={isLeader}
                 isTeamLeader={isTeamLeader}
                 category={category}
                 onRemove={onRemove}
@@ -103,20 +104,23 @@ const ParticipantMenu = ({
                 onMandateLeader={onMandateLeader}
               />
             ))}
-            {searchedExcludeMember && searchedExcludeMember.length > 0 && <Divider />}
-            {searchedExcludeMember.map((member: Member) => (
-              <ParticipantItem
-                key={member.id}
-                member={member}
-                type="EXCLUDE"
-                isLeader={user?.memberId === searchedLeader?.id}
-                isTeamLeader={isTeamLeader}
-                category={category}
-                onRemove={onRemove}
-                onAdd={onAdd}
-                onMandateLeader={onMandateLeader}
-              />
-            ))}
+            {(isLeader || !isTeamLeader) && searchedExcludeMember?.length > 0 && (
+              <>
+                <Divider />
+                {searchedExcludeMember.map((member: Member) => (
+                  <ParticipantItem
+                    key={member.id}
+                    member={member}
+                    type="EXCLUDE"
+                    isLeader={isLeader}
+                    category={category}
+                    onRemove={onRemove}
+                    onAdd={onAdd}
+                    onMandateLeader={onMandateLeader}
+                  />
+                ))}
+              </>
+            )}
           </Flex>
         </Flex>
       </Flex>

--- a/src/components/ParticipantMenu/types.ts
+++ b/src/components/ParticipantMenu/types.ts
@@ -9,6 +9,8 @@ export interface ParticipantMenuProps extends FlexProps {
   excludeMembers?: Member[];
   children: ReactNode;
   isOpen: boolean;
+  isTeamLeader?: boolean;
+  category: 'teams' | 'studies';
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   onRemove?: (member: Member) => void;
   onAdd?: (member: Member) => void;
@@ -19,6 +21,8 @@ export interface ParticipantItemProps {
   member: Member;
   type: 'LEADER' | 'INCLUDE' | 'EXCLUDE';
   isLeader?: boolean;
+  isTeamLeader?: boolean;
+  category: 'teams' | 'studies';
   onRemove: (member: Member) => void;
   onAdd: (member: Member) => void;
   onMandateLeader: (member: Member) => void;

--- a/src/containers/study/StudyParticipantMenu/index.tsx
+++ b/src/containers/study/StudyParticipantMenu/index.tsx
@@ -15,6 +15,7 @@ const StudyParticipantMenu = ({
   studyId,
   teamId,
   leaderId,
+  isTeamLeader,
   studyMembers: originStudyMembers,
   refetchMembers = () => {},
 }: StudyParticipantMenuProps) => {
@@ -67,6 +68,8 @@ const StudyParticipantMenu = ({
       isOpen={isOpen}
       setIsOpen={setIsOpen}
       leader={leader}
+      isTeamLeader={isTeamLeader}
+      category="studies"
       includeMembers={includeMembers}
       excludeMembers={excludeMembers}
       onAdd={handleAddMember}

--- a/src/containers/study/StudyParticipantMenu/types.ts
+++ b/src/containers/study/StudyParticipantMenu/types.ts
@@ -4,6 +4,7 @@ export interface StudyParticipantMenuProps {
   studyId: number;
   teamId: number;
   leaderId: number;
+  isTeamLeader: boolean;
   studyMembers: StudyMember[];
   refetchMembers?: () => void;
 }

--- a/src/containers/team/teamMember/index.tsx
+++ b/src/containers/team/teamMember/index.tsx
@@ -68,6 +68,7 @@ const TeamMember = ({ teamId, teamName }: { teamId: number; teamName: string }) 
         leader={teamLeader}
         includeMembers={teamMembers}
         isOpen={isOpen}
+        category="teams"
         setIsOpen={setIsOpen}
         onRemove={handleRemoveButtonClick}
         onMandateLeader={handleMandateLeaderButtonClick}


### PR DESCRIPTION
### 관련 이슈

- close #390 

### 작업 요약

- 스터디페이지에서 팀장도 스터디장 및 스터디원을 삭제할 수 있게 하였습니다.

### 작업 상세 설명

- 팀장은 스터디장 및 스터디원 삭제만 가능하고 스터디장 위임은 불가능하여, 삭제 표시만 뜨도록 하였습니다.
- 스터디장이 아닌 팀장에게는 스터디원 추가 표시도 뜨지 않도록 하였습니다.

### 리뷰 요구 사항

- 백엔드 배포가 되지 않아 아직 확인은 못해봤기에 추후에 확인이 필요합니다.

### 미리 보기

- 추후 추가 예정
