### PR TITLE
Feature/#392 스터디페이지 학습자료 공개 범위 옵션 제거

### DIFF
--- a/src/app/team/[teamId]/document/page.tsx
+++ b/src/app/team/[teamId]/document/page.tsx
@@ -36,6 +36,7 @@ const Page = ({ params }: { params: { teamId: number } }) => {
       </Flex>
       <Documents groupId={params.teamId} category="teams" refetchTrigger={openCreateModal} />
       <CreateDocumentModal
+        isTeam
         isOpen={openCreateModal}
         onClose={() => setOpenCreateModal(false)}
         categoryData={categoryData}

--- a/src/app/team/[teamId]/page.tsx
+++ b/src/app/team/[teamId]/page.tsx
@@ -249,6 +249,7 @@ const Page = ({ params }: { params: { teamId: number } }) => {
         studyInfo={null}
       />
       <CreateDocumentModal
+        isTeam
         isOpen={isCreateDocumentModalOpen}
         onClose={() => setIsCreateDocumentModalOpen(false)}
         categoryData={categoryData}

--- a/src/components/DocumentCard/index.tsx
+++ b/src/components/DocumentCard/index.tsx
@@ -7,7 +7,7 @@ import S3_URL from '@/constants/s3Url';
 import DocumentModal from '@/containers/study/DocumentModal';
 import { DocumentList } from '@/types';
 
-const DocumentCard = ({ id, title, description, date, setReload, files, type }: DocumentList) => {
+const DocumentCard = ({ isTeam = false, id, title, description, date, setReload, files, type }: DocumentList) => {
   const [docsModalOpen, setIsDocsModalOpen] = useState<boolean>(false);
 
   const firstImg = () => {
@@ -38,7 +38,13 @@ const DocumentCard = ({ id, title, description, date, setReload, files, type }: 
       onClick={() => setIsDocsModalOpen(true)}
       rounded="xl"
     >
-      <DocumentModal id={id} isOpen={docsModalOpen} setIsDocsModalOpen={setIsDocsModalOpen} setReload={setReload} />
+      <DocumentModal
+        isTeam={isTeam}
+        id={id}
+        isOpen={docsModalOpen}
+        setIsDocsModalOpen={setIsDocsModalOpen}
+        setReload={setReload}
+      />
 
       <Image h="60" objectFit="cover" alt="study card" rounded="sm" src={firstImg()} />
       <CardBody px="2">

--- a/src/containers/document/Documents/index.tsx
+++ b/src/containers/document/Documents/index.tsx
@@ -37,6 +37,7 @@ const Documents = ({ groupId, category, refetchTrigger = false }: DocumentPagePr
           <Grid gap={{ sm: '2', md: '4', xl: '8' }} templateColumns={`repeat(${itemsPerPage / 2}, 1fr)`} w="100%">
             {currentData.map((data) => (
               <DocumentCard
+                isTeam={category === 'teams'}
                 id={data.id}
                 key={data.id}
                 title={data.title}

--- a/src/containers/study/CreateDocumentModal/index.tsx
+++ b/src/containers/study/CreateDocumentModal/index.tsx
@@ -25,7 +25,7 @@ const DocumentBoxIcon = {
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
-const CreateDocumentModal = ({ isOpen, onClose, categoryData, category }: DocumentModalProps) => {
+const CreateDocumentModal = ({ isTeam = false, isOpen, onClose, categoryData, category }: DocumentModalProps) => {
   const [doctype, setDocType] = useState<DocumentType>('IMAGE');
   const [docList, setDocList] = useState<DocumentList>({
     IMAGE: [],
@@ -328,14 +328,16 @@ const CreateDocumentModal = ({ isOpen, onClose, categoryData, category }: Docume
             </Flex>
           </>
         )}
-        <StyledRadioGroup
-          title="공개 범위"
-          defaultValue={category === 'create' ? 'ALL' : (categoryData as DocumentDetail).accessType}
-          onChange={handleChange}
-        >
-          <StyledRadio value="ALL">전체 공개</StyledRadio>
-          <StyledRadio value="TEAM">팀 공개</StyledRadio>
-        </StyledRadioGroup>
+        {isTeam && (
+          <StyledRadioGroup
+            title="공개 범위"
+            defaultValue={category === 'create' ? 'ALL' : (categoryData as DocumentDetail).accessType}
+            onChange={handleChange}
+          >
+            <StyledRadio value="ALL">전체 공개</StyledRadio>
+            <StyledRadio value="TEAM">팀 공개</StyledRadio>
+          </StyledRadioGroup>
+        )}
       </Flex>
     </ActionModal>
   );

--- a/src/containers/study/CreateDocumentModal/type.ts
+++ b/src/containers/study/CreateDocumentModal/type.ts
@@ -12,6 +12,7 @@ export interface UpdateDocument {
 }
 
 export interface DocumentModalProps {
+  isTeam?: boolean;
   isOpen: boolean;
   onClose: () => void;
   categoryData: CreateDocument | DocumentDetail | undefined;

--- a/src/containers/study/DocumentModal/index.tsx
+++ b/src/containers/study/DocumentModal/index.tsx
@@ -16,7 +16,7 @@ import { DocumentDetail } from '@/types';
 
 import { DocumentModalProps } from './types';
 
-const DocumentModal = ({ id, isOpen, setIsDocsModalOpen, setReload }: DocumentModalProps) => {
+const DocumentModal = ({ isTeam = false, id, isOpen, setIsDocsModalOpen, setReload }: DocumentModalProps) => {
   const [createDocsModalOpen, setIsCreateDocsModalOpen] = useState<boolean>(false);
 
   const {
@@ -101,7 +101,13 @@ const DocumentModal = ({ id, isOpen, setIsDocsModalOpen, setReload }: DocumentMo
             ))}
         </Flex>
       </Box>
-      <CreateDocumentModal isOpen={createDocsModalOpen} onClose={EditDocs} categoryData={document} category="update" />
+      <CreateDocumentModal
+        isTeam={isTeam}
+        isOpen={createDocsModalOpen}
+        onClose={EditDocs}
+        categoryData={document}
+        category="update"
+      />
     </ActionModal>
   );
 };

--- a/src/containers/study/DocumentModal/types.ts
+++ b/src/containers/study/DocumentModal/types.ts
@@ -6,6 +6,7 @@ export interface DocumentData {
 }
 
 export interface DocumentModalProps {
+  isTeam?: boolean;
   id: number;
   isOpen: boolean;
   setIsDocsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/containers/team/DocumentGridView/index.tsx
+++ b/src/containers/team/DocumentGridView/index.tsx
@@ -10,6 +10,7 @@ const DocumentGridView = ({ documentArray, setReload = () => {} }: DocumentGridV
       {documentArray?.map((document) => {
         return (
           <DocumentCard
+            isTeam
             key={document.id}
             id={document.id}
             title={document.title}

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,7 @@ export interface Document {
 }
 
 export interface DocumentList {
+  isTeam?: boolean;
   id: number;
   title: string;
   description: string;


### PR DESCRIPTION
### 관련 이슈

- close #392

### 작업 요약

- 스터디페이지 학습자료 공개 범위 옵션을 제거하였습니다.

### 작업 상세 설명

- 스터디페이지의 학습자료는 오직 스터디원만 볼 수 있기에 공개 범위 의미가 없어져 옵션을 제거하였습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간: 1분

### 미리 보기

![스크린샷 2025-02-09 205317](https://github.com/user-attachments/assets/fbb5747d-5c25-47e0-b80e-8fa66f3807f2)
![스크린샷 2025-02-09 205255](https://github.com/user-attachments/assets/0d72ce9f-7b0d-4023-b771-da911858bd46)
