### PR TITLE
Feature/#394 종료 날짜 지정 안 했을 시 스터디페이지에서 종료 날짜 안 보이게 수정

### DIFF
--- a/src/app/team/[teamId]/study/[studyId]/page.tsx
+++ b/src/app/team/[teamId]/study/[studyId]/page.tsx
@@ -106,7 +106,7 @@ const Page = ({ params }: { params: { teamId: number; studyId: number } }) => {
                 status={studyData.status}
                 progress={studyData.studyProgressRatio}
                 startAt={new Date(studyData.startDate)}
-                endAt={new Date(studyData.endDate)}
+                endAt={studyData.endDate ? new Date(studyData.endDate) : null}
               />
             </>
           )}

--- a/src/containers/study/StudyInfoCard/index.tsx
+++ b/src/containers/study/StudyInfoCard/index.tsx
@@ -23,7 +23,7 @@ const StudyInfoCard = ({ progress, startAt, endAt, status }: StudyInfoCardProps)
           스터디 기간
         </Text>
         <Text display={{ base: 'none', md: 'block' }}>
-          {dateFormat(startAt, '/')} - {dateFormat(endAt, '/')}
+          {dateFormat(startAt, '/')} - {endAt ? dateFormat(endAt, '/') : ''}
         </Text>
       </Flex>
     </Card>

--- a/src/containers/study/StudyInfoCard/types.ts
+++ b/src/containers/study/StudyInfoCard/types.ts
@@ -1,7 +1,7 @@
 export interface StudyInfoCardProps {
   progress: number;
   startAt: Date;
-  endAt: Date;
+  endAt: Date | null;
   status: string;
 }
 


### PR DESCRIPTION
### 관련 이슈

- close #394

### 작업 요약

- 스터디 상세 정보에서 종료 날짜가 null일 때 1970/1/1로 표시되던 걸 빈문자열로 처리했습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간: 30초

### 미리 보기
![image](https://github.com/user-attachments/assets/651e007c-cbcf-4dca-b4bf-b82272181db3)
