### PR TITLE
Feature/#396 스터디라는 단어만 다른 색상으로 표시되도록 구현

### DIFF
--- a/src/components/Sidebar/Button/CategoryButton/index.tsx
+++ b/src/components/Sidebar/Button/CategoryButton/index.tsx
@@ -3,10 +3,22 @@ import { BsCircleFill } from 'react-icons/bs';
 
 import { CategoryButtonProps } from '../../type';
 
-const CategoryButton = ({ path, text, isSelected, isTeam = false, isTeamMatch = false }: CategoryButtonProps) => {
+const CategoryButton = ({
+  path,
+  text,
+  isSelected,
+  isTeam = false,
+  isTeamMatch = false,
+  isStudy = false,
+}: CategoryButtonProps) => {
   return (
     <Button
       as="a"
+      sx={{
+        '&:hover > p': {
+          color: isSelected ? 'white' : 'orange',
+        },
+      }}
       justifyContent="flex-start"
       h="fit-content"
       p="2"
@@ -21,6 +33,11 @@ const CategoryButton = ({ path, text, isSelected, isTeam = false, isTeamMatch = 
       <Text textStyle={isTeam ? 'bold_xl' : 'md'} ml={isTeam ? '0px' : '24px'}>
         {text}
       </Text>
+      {isStudy && (
+        <Text textStyle="md" ml="4px" color={isSelected ? 'gray.100' : 'gray.200'}>
+          스터디
+        </Text>
+      )}
     </Button>
   );
 };

--- a/src/components/Sidebar/Category/index.tsx
+++ b/src/components/Sidebar/Category/index.tsx
@@ -24,8 +24,9 @@ const Category = ({ id, name, subCategory }: CategoryProps) => {
           <CategoryButton
             key={`study-${study.id}`}
             path={studyPath}
-            text={`${study.name} 스터디`}
+            text={study.name}
             isSelected={currentPath === studyPath}
+            isStudy
           />
         );
       })}

--- a/src/components/Sidebar/type.ts
+++ b/src/components/Sidebar/type.ts
@@ -4,6 +4,7 @@ export interface CategoryButtonProps {
   isSelected: boolean;
   isTeam?: boolean;
   isTeamMatch?: boolean;
+  isStudy?: boolean;
 }
 
 export interface SidebarIconButtonProps {

--- a/src/components/StudyCard/index.tsx
+++ b/src/components/StudyCard/index.tsx
@@ -54,6 +54,9 @@ const StudyCard = ({
         <CardHeader py="2">
           <Text textStyle="bold_md" overflow="hidden" textAlign="center" whiteSpace="nowrap" textOverflow="ellipsis">
             {name}
+            <Text as="span" ml="2" color="orange_dark">
+              스터디
+            </Text>
           </Text>
         </CardHeader>
         <CardBody py="0" textAlign="center" id={cropId.toString()}>


### PR DESCRIPTION
### 관련 이슈

- close #396 

### 작업 요약

- 사이드바에서 스터디 글자는 다른 색상으로 나타내고, 스터디 카드에는 스터디 글자를 붙였습니다.

### 작업 상세 설명

- 색상 선택에 고민이 많았는데, 사이드바가 어두운 초록 계열이고 글자가 흰색이므로, 너무 튀지 않는 범위 내에서 조정하고자 회색 계열을 적용했습니다. 또한, 스터디 카드의 경우 스터디나 학습 자료가 없을 때 표시되는 문구의 색상을 그대로 가져왔습니다.
- 이때 기존에 없던 gray 색상을 새로 사용했지만, 재사용되진 않을 것 같아 일단 코드에 바로 적용해두었습니다.
- 저의 타고나지 않은 미적 감각을 잘 알고 있기에.. 언제든지 색상 추천을 해주셔도 좋습니다! (대환영)

### 리뷰 요구 사항

- 리뷰 예상 시간: 1분

### 미리 보기

- 사이드바
![스크린샷 2025-02-13 133127](https://github.com/user-attachments/assets/b46f3355-1a2d-484f-8b44-36461fd3db48) ![스크린샷 2025-02-13 133138](https://github.com/user-attachments/assets/041001fc-c80c-4ad3-9446-f73c48fd748b)

- 스터디 카드
![image](https://github.com/user-attachments/assets/8ae8cc08-531a-4d28-afa7-45bd8552eafe)
