### PR TITLE
Feature/#397 학습자료 상세 조회 시 파일 경로가 아닌 파일명으로 표시

### DIFF
--- a/src/containers/study/DocumentModal/index.tsx
+++ b/src/containers/study/DocumentModal/index.tsx
@@ -88,7 +88,7 @@ const DocumentModal = ({ isTeam = false, id, isOpen, setIsDocsModalOpen, setRelo
                 <IconBox
                   // leftIcon={data.type === 'pdf' ? <BiFile size={30} /> : <BsFolder2Open size={30} />}
                   leftIcon={<BiFile size={30} />}
-                  content={data.url.toString()}
+                  content={data.name}
                   cursor="pointer"
                 />
               </Link>

--- a/src/mocks/documentCard.ts
+++ b/src/mocks/documentCard.ts
@@ -12,6 +12,7 @@ const documentCardData: DocumentList[] = [
     files: [
       {
         id: 1,
+        name: '자료이름1',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -28,6 +29,7 @@ const documentCardData: DocumentList[] = [
     files: [
       {
         id: 2,
+        name: '자료이름2',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -44,6 +46,7 @@ const documentCardData: DocumentList[] = [
     files: [
       {
         id: 3,
+        name: '자료이름3',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -61,6 +64,7 @@ const documentCardData: DocumentList[] = [
     files: [
       {
         id: 4,
+        name: '자료이름4',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -77,6 +81,7 @@ const documentCardData: DocumentList[] = [
     files: [
       {
         id: 5,
+        name: '자료이름5',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -94,6 +99,7 @@ const documentCardData: DocumentList[] = [
     files: [
       {
         id: 6,
+        name: '자료이름6',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -110,6 +116,7 @@ const documentCardData: DocumentList[] = [
     files: [
       {
         id: 7,
+        name: '자료이름7',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -126,6 +133,7 @@ const documentCardData: DocumentList[] = [
     files: [
       {
         id: 8,
+        name: '자료이름8',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],

--- a/src/mocks/documentCardAll.ts
+++ b/src/mocks/documentCardAll.ts
@@ -11,6 +11,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 11,
+        name: '자료이름1',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -26,6 +27,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 22,
+        name: '자료이름2',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -41,6 +43,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 33,
+        name: '자료이름3',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -56,6 +59,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 44,
+        name: '자료이름4',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -71,6 +75,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 55,
+        name: '자료이름5',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -86,6 +91,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 66,
+        name: '자료이름6',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -101,6 +107,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 77,
+        name: '자료이름7',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -116,6 +123,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 88,
+        name: '자료이름8',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -131,6 +139,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 99,
+        name: '자료이름9',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -146,6 +155,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 1010,
+        name: '자료이름10',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -161,6 +171,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 1111,
+        name: '자료이름11',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],
@@ -176,6 +187,7 @@ const documentCardDataAll: DocumentList[] = [
     files: [
       {
         id: 1212,
+        name: '자료이름12',
         url: 'https://images.unsplash.com/photo-1531403009284-440f080d1e12?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
       },
     ],

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,6 +125,7 @@ export interface DocumentList {
 
 export interface DocumentFile {
   id: number;
+  name: string;
   url: string;
 }
 


### PR DESCRIPTION
### 관련 이슈

- close #397

### 작업 요약

- 학습자료 상세 조회 시 파일이 파일 경로로 보이던 현상을 파일명이 보이도록 수정했습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간: 5초

### 미리 보기

![스크린샷 2025-02-13 141850](https://github.com/user-attachments/assets/6533c506-e37a-427f-8b26-e62ec13e83a2)
