### PR TITLE
Feature/#400 학습자료 URL 프로토콜이 없는 경우 절대 경로로 변환

### DIFF
--- a/src/containers/study/DocumentModal/index.tsx
+++ b/src/containers/study/DocumentModal/index.tsx
@@ -39,6 +39,14 @@ const DocumentModal = ({ isTeam = false, id, isOpen, setIsDocsModalOpen, setRelo
     setReload((prev: boolean) => !prev);
   };
 
+  const absoluteUrl = (url: string) => {
+    try {
+      return new URL(url).href;
+    } catch {
+      return `https://${url}`;
+    }
+  };
+
   return (
     <ActionModal
       isOpen={isOpen}
@@ -95,7 +103,7 @@ const DocumentModal = ({ isTeam = false, id, isOpen, setIsDocsModalOpen, setRelo
             ))}
           {document?.type === 'URL' &&
             document.files.map((data) => (
-              <Link key={data.url} href={data.url} target="_blank" rel="noopener noreferrer">
+              <Link key={data.url} href={absoluteUrl(data.url)} target="_blank" rel="noopener noreferrer">
                 <IconBox leftIcon={<BiLink size="30" />} content={data.url} cursor="pointer" />
               </Link>
             ))}


### PR DESCRIPTION
### 관련 이슈

- close #400

### 작업 요약

- 학습자료 URL에 프로토콜이 없는 경우, `https://`를 자동으로 추가하여 절대 경로로 변환했습니다.

### 리뷰 요구 사항

- 리뷰 예상 시간: 1분

### 미리 보기

https://github.com/user-attachments/assets/961b0ac9-a844-4db3-bf0f-ef3c8bbce711
