### PR TITLE
Feature/#402 팀 및 스터디명이 긴 경우 소개글과 다른 컴포넌트가 겹치는 현상 수정

### DIFF
--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -99,7 +99,6 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
         alignContent="center"
         display={{ base: isHovered ? 'block' : 'none', lg: 'none' }}
         w={{ base: '72', '2xl': '96' }}
-        h="100%"
         p="2"
         bg="white"
         borderRadius="base"

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -1,5 +1,5 @@
-import { Text, Flex, Avatar, Box } from '@chakra-ui/react';
-import { useState } from 'react';
+import { Text, Flex, Avatar, Box, keyframes } from '@chakra-ui/react';
+import { useEffect, useRef, useState } from 'react';
 
 import S3_URL from '@/constants/s3Url';
 
@@ -7,6 +7,22 @@ import { TitleProps } from './types';
 
 const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
   const [isHovered, setIsHovered] = useState(false);
+  const [textWidth, setTextWidth] = useState(0);
+  const textRef = useRef<HTMLParagraphElement>(null);
+
+  const textFlow = keyframes`
+    from { transform: translateX(0); }
+    to { transform: translateX(calc(-${textWidth}px + 100%)); }
+  `;
+  const textFlowAnimation = `${textFlow} 4s linear forwards`;
+
+  useEffect(() => {
+    if (textRef.current) {
+      textRef.current.style.maxWidth = 'none';
+      setTextWidth(textRef.current.scrollWidth);
+      textRef.current.style.maxWidth = '';
+    }
+  }, [name]);
 
   return (
     <Flex pos="relative" align="center" gap="3">
@@ -19,14 +35,26 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
           src={imageUrl ? S3_URL(imageUrl) : '/images/doore_logo.png'}
         />
       )}
-      <Text
+      <Box
+        ref={textRef}
         textStyle="bold_3xl"
+        overflow="hidden"
+        maxW={isTeam ? { base: '56', lg: '64', xl: '96' } : { base: '56', md: '64', lg: '72', xl: '96' }}
+        whiteSpace="nowrap"
         cursor="default"
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        {name}
-      </Text>
+        <Text
+          display="block"
+          overflow={isHovered ? 'visible' : 'hidden'}
+          animation={isHovered ? textFlowAnimation : 'none'}
+          whiteSpace="nowrap"
+          textOverflow={isHovered ? 'unset' : 'ellipsis'}
+        >
+          {name}
+        </Text>
+      </Box>
 
       <Box pos="relative" display={{ base: 'none', lg: 'block' }} w="10" h="12" px="2">
         <Box pos="absolute" zIndex="1" top="50%" w="5" h="5" bg="white" transform="translate(0%, -50%) rotate(45deg)" />
@@ -34,7 +62,7 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
           pos="absolute"
           left="4"
           align="center"
-          w={{ base: '72', '2xl': '96' }}
+          w={isTeam ? { base: '72', '2xl': '96' } : { base: '56', xl: '72', '2xl': '96' }}
           h="100%"
           px="3"
           bg="white"


### PR DESCRIPTION
### 관련 이슈

- close #402 

### 작업 요약

- 팀 및 스터디 이름이 길면 다른 컴포넌트와 겹치는 현상을 수정했습니다.

### 작업 상세 설명

- 팀 및 스터디 이름이 길 경우 기본적으로 `ellipsis`를 적용하여 생략되도록 하며, 마우스를 호버하면 애니메이션 효과를 통해 전체 이름을 확인할 수 있도록 구현하였습니다.
- `textWidth`를 정확하게 측정하기 위해, `maxWidth`를 일시적으로 해제한 후 `scrollWidth`를 측정하고, 이후 원래 상태로 복구하였습니다. 이는 `maxWidth`가 설정된 상태에서 `scrollWidth`를 측정하면, 실제 텍스트 길이가 아닌 `maxWidth` 값만 반영되는 문제를 방지하기 위함입니다. `ref`를 `<Text>` 요소에 직접 적용하면 `maxWidth`를 변경하지 않고도 `textWidth`를 측정할 수 있지만, 이 경우 `name`의 길이에 따라 텍스트가 끝났음에도 불구하고 애니메이션이 과도하게 동작하기도 했습니다. 따라서 이를 방지하기 위해 부모 요소인 `<Box>`에 `ref`를 적용하였습니다. (이걸 몰라서 엄한 곳에서 원인을 찾고자 4시간 동안 헤맸습니다..(｡•́︿•̀｡))

### 리뷰 요구 사항

- 처음엔 툴팁으로 할까 고민하다가 현재 `description`이 그런 형태이니 애니메이션이 나을 것 같아 적용했는데 괜찮나요?!
- 리뷰 예상 시간: 2분

### 미리 보기

https://github.com/user-attachments/assets/220f773c-21fa-4929-b030-a05a7358edfa