### PR TITLE
Feature/#407 스터디 학습자료 공개범위 문구를 '스터디 공개'로 수정

### DIFF
--- a/src/containers/study/DocumentModal/index.tsx
+++ b/src/containers/study/DocumentModal/index.tsx
@@ -68,7 +68,11 @@ const DocumentModal = ({ isTeam = false, id, isOpen, setIsDocsModalOpen, setRelo
           </Flex>
           <Flex justify="space-between">
             <Text cursor="default"> 공개범위</Text>
-            <Text cursor="default"> {document?.accessType === 'ALL' ? '전체 공개' : '팀 공개'} </Text>
+            {isTeam ? (
+              <Text cursor="default"> {document?.accessType === 'ALL' ? '전체 공개' : '팀 공개'} </Text>
+            ) : (
+              <Text cursor="default">스터디 공개</Text>
+            )}
           </Flex>
         </Flex>
       </Flex>


### PR DESCRIPTION
### 관련 이슈

- close #407

### 작업 요약

- 스터디 학습자료 공개범위 문구를 '스터디 공개'로 수정하였습니다.

### 미리 보기

![image](https://github.com/user-attachments/assets/2573e0b0-cbfb-4461-bbc5-6197af7fee45)
