### PR TITLE
Feature/#412 팀 기본 이미지 뜨지 않는 현상 수정

### DIFF
--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -32,7 +32,7 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
           borderColor="gray.100"
           shadow="none"
           size="md"
-          src={imageUrl !== 'TEMP_URL' ? S3_URL(imageUrl) : S3_URL('default/logo.png')}
+          src={imageUrl && imageUrl !== 'TEMP_URL' ? S3_URL(imageUrl) : S3_URL('default/logo.png')}
         />
       )}
       <Box

--- a/src/components/Title/index.tsx
+++ b/src/components/Title/index.tsx
@@ -32,7 +32,7 @@ const Title = ({ isTeam, name, description, imageUrl }: TitleProps) => {
           borderColor="gray.100"
           shadow="none"
           size="md"
-          src={imageUrl ? S3_URL(imageUrl) : '/images/doore_logo.png'}
+          src={imageUrl !== 'TEMP_URL' ? S3_URL(imageUrl) : S3_URL('default/logo.png')}
         />
       )}
       <Box

--- a/src/components/Title/types.ts
+++ b/src/components/Title/types.ts
@@ -2,5 +2,5 @@ export interface TitleProps {
   isTeam?: boolean;
   name: string;
   description: string;
-  imageUrl: string;
+  imageUrl?: string;
 }

--- a/src/components/Title/types.ts
+++ b/src/components/Title/types.ts
@@ -2,5 +2,5 @@ export interface TitleProps {
   isTeam?: boolean;
   name: string;
   description: string;
-  imageUrl?: string;
+  imageUrl: string;
 }


### PR DESCRIPTION
### 관련 이슈

- close #412

### 작업 요약

- 팀 기본 이미지 뜨지 않는 현상 수정

### 작업 상세 설명

- S3 주소 바뀐 걸로 명시

### 미리 보기

![image](https://github.com/user-attachments/assets/a19082f2-b610-4a65-91a5-a71b98d5b3c5)
