### PR TITLE
Feature/#414 팀 출석률 대신 팀 순위 적는 것으로 변경

### DIFF
--- a/src/app/team/[teamId]/page.tsx
+++ b/src/app/team/[teamId]/page.tsx
@@ -10,7 +10,7 @@ import { BsLink45Deg } from 'react-icons/bs';
 import { getDocumentList } from '@/app/api/document';
 import { getGarden } from '@/app/api/garden';
 import { getStudies } from '@/app/api/study';
-import { postInviteTeam, useGetTeamInfoQuery } from '@/app/api/team';
+import { getTeams, postInviteTeam, useGetTeamInfoQuery } from '@/app/api/team';
 import { myTeamAtom } from '@/atom';
 import Garden3D from '@/components/Garden3D';
 import TabButton from '@/components/TabButton';
@@ -19,19 +19,21 @@ import { CARD_PER_PAGE, TEAM_CATEGORY_INFOS } from '@/constants/team';
 import CreateDocumentModal from '@/containers/study/CreateDocumentModal';
 import { CreateDocument } from '@/containers/study/CreateDocumentModal/type';
 import StudyModal from '@/containers/study/Modal/StudyModal';
-import AttendanceRate from '@/containers/team/AttendanceRate';
 import DocumentGridView from '@/containers/team/DocumentGridView';
 import NavigationButton from '@/containers/team/NavigationButton';
 import StudyGridView from '@/containers/team/StudyGridView';
 import SuggestionCreate from '@/containers/team/SuggestionCreate';
 import TeamControlPanel from '@/containers/team/TeamControlPanel';
 import TeamMember from '@/containers/team/teamMember';
+import TeamRate from '@/containers/team/TeamRank';
 import { useMutateWithToken } from '@/hooks/useFetchWithToken';
 import useGetUser from '@/hooks/useGetUser';
-import { DocumentList, Garden, StudyRank } from '@/types';
+import { DocumentList, Garden, StudyRank, TeamRank } from '@/types';
 
 const Page = ({ params }: { params: { teamId: number } }) => {
   const { data: teamInfo } = useGetTeamInfoQuery(params.teamId);
+  const [teamRank, setTeamRank] = useState<number>(0);
+  const [teamRankMax, setTeamRankMax] = useState<number>(0);
   const [garden, setGarden] = useState<Garden[]>([]);
   const [category, setCategory] = useState<string>(TEAM_CATEGORY_INFOS[0].name);
   const [cardIdx, setCardIdx] = useState<number>(0);
@@ -67,6 +69,18 @@ const Page = ({ params }: { params: { teamId: number } }) => {
       });
     }
   };
+
+  useEffect(() => {
+    getTeams().then((res) => {
+      if (!res.ok) return;
+      const matchedTeam = res.body.find((team: TeamRank) => team.teamReferenceResponse.id === Number(params.teamId));
+      if (matchedTeam) {
+        const teamWithRank = { ...matchedTeam, rank: res.body.indexOf(matchedTeam) + 1 };
+        setTeamRank(teamWithRank.rank);
+      }
+      setTeamRankMax(res.body.length);
+    });
+  }, []);
 
   useEffect(() => {
     getGarden(params.teamId).then((res) => {
@@ -213,9 +227,7 @@ const Page = ({ params }: { params: { teamId: number } }) => {
               />
             </Box>
           </Box>
-
-          {/* TODO  진행도 */}
-          <AttendanceRate attendanceRate={teamInfo?.body.attendanceRatio} />
+          <TeamRate teamRank={teamRank} maxRank={teamRankMax} />
         </Flex>
 
         <Flex direction="column" flex="1" gap="4">

--- a/src/containers/team/AttendanceRate/types.ts
+++ b/src/containers/team/AttendanceRate/types.ts
@@ -1,3 +1,0 @@
-export interface AttendanceRateProps {
-  attendanceRate: number;
-}

--- a/src/containers/team/TeamRank/index.tsx
+++ b/src/containers/team/TeamRank/index.tsx
@@ -1,8 +1,10 @@
 import { CircularProgress, CircularProgressLabel, useBreakpointValue, Text } from '@chakra-ui/react';
 
-import { AttendanceRateProps } from './types';
+import { TeamRankProps } from './types';
 
-const AttendanceRate = ({ attendanceRate }: AttendanceRateProps) => {
+const TeamRank = ({ teamRank, maxRank }: TeamRankProps) => {
+  const progressValue = ((maxRank - teamRank + 1) / maxRank) * 100;
+
   return (
     <CircularProgress
       pos="absolute"
@@ -13,13 +15,13 @@ const AttendanceRate = ({ attendanceRate }: AttendanceRateProps) => {
       transform={{ base: 'translateY(0%)', lg: 'translateY(-50%)' }}
       size={useBreakpointValue({ base: 24, md: 40, lg: 56 })}
       thickness="5"
-      value={attendanceRate}
+      value={progressValue}
     >
       <CircularProgressLabel color="orange">
-        <Text textStyle={useBreakpointValue({ base: 'bold_md', md: 'bold_2xl' })}>{attendanceRate}%</Text>
+        <Text textStyle={useBreakpointValue({ base: 'bold_md', md: 'bold_2xl' })}>{teamRank}등</Text>
       </CircularProgressLabel>
     </CircularProgress>
   );
 };
 
-export default AttendanceRate;
+export default TeamRank;

--- a/src/containers/team/TeamRank/types.ts
+++ b/src/containers/team/TeamRank/types.ts
@@ -1,0 +1,4 @@
+export interface TeamRankProps {
+  teamRank: number;
+  maxRank: number;
+}


### PR DESCRIPTION
### 관련 이슈

- close #414

### 작업 요약

- 팀 출석률 대신 팀 순위 적는 것으로 변경

### 작업 상세 설명

- 팀 순위가 높을수록 진행률이 많이 차도록 표시

### 미리 보기

![image](https://github.com/user-attachments/assets/ac939824-9e11-4402-8ed3-eebf7d7a9ffa)
![image](https://github.com/user-attachments/assets/99ac0b7b-deed-4505-b111-0fc654d47515)
