### PR TITLE
Feature/#442 마이페이지 스터디 카드 클릭 시 해당 스터디로 이동 안되는 버그 수정

### DIFF
--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -349,7 +349,7 @@ const Page = () => {
               filteredStudies.map((study, index) => (
                 <StudyCard
                   key={study.id}
-                  teamId={2}
+                  teamId={study.teamId}
                   id={study.id}
                   name={study.name}
                   description={study.description}


### PR DESCRIPTION
### 관련 이슈

- close #442

### 작업 요약

- API 응답에 teamId가 포함되도록 백엔드에 요청하였고, 프론트엔드에서 기존의 임의 값을 해당 응답 값으로 대체했습니다.

### 미리 보기

https://github.com/user-attachments/assets/b4ad7a92-b10f-44d3-ac0e-611627a3d7f3
