### PR TITLE
Feature/#464 팀 정보 수정 시 팀 이미지 없을 때 빈 이미지 표시 문제 수정

### DIFF
--- a/src/containers/team/Modal/TeamModal/index.tsx
+++ b/src/containers/team/Modal/TeamModal/index.tsx
@@ -228,7 +228,7 @@ const TeamModal = ({ teamInfo, isOpen, onClose }: TeamModalProps) => {
               variant="orange_light"
             />
           </Flex>
-          {thumbnailPath ? (
+          {thumbnailPath && thumbnailPath !== 'TEMP_URL' ? (
             <Image w="40" alt="thumbnail" src={S3_URL(thumbnailPath)} />
           ) : (
             thumbnail && <Image w="40" alt="thumbnail" src={URL.createObjectURL(thumbnail)} />


### PR DESCRIPTION
### 관련 이슈

- close #464

### 작업 요약

- 팀 정보 수정 시 팀 이미지 없을 때 빈 이미지 표시 문제 수정

### 작업 상세 설명

- thumbnailPath가 TEMP_URL일 때 따로 처리
